### PR TITLE
Add `PreVerification` table to DB

### DIFF
--- a/prisma/migrations/20251221213651_add_preverification_table/migration.sql
+++ b/prisma/migrations/20251221213651_add_preverification_table/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "PreVerificationStatus" AS ENUM ('PENDING', 'VERIFIED');
+
+-- CreateTable
+CREATE TABLE "PreVerification" (
+    "id" UUID NOT NULL,
+    "email" VARCHAR(255) NOT NULL,
+    "firstName" VARCHAR(100) NOT NULL,
+    "lastName" VARCHAR(100) NOT NULL,
+    "companyName" VARCHAR(225) NOT NULL,
+    "phoneCountryCode" VARCHAR(5),
+    "phoneNumber" VARCHAR(15),
+    "status" "PreVerificationStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PreVerification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PreVerification_email_key" ON "PreVerification"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,3 +14,20 @@ datasource db {
   provider = "postgresql"
 }
 
+enum PreVerificationStatus {
+  PENDING
+  VERIFIED
+}
+
+model PreVerification {
+  id               String                @id @default(uuid()) @db.Uuid
+  email            String                @unique @db.VarChar(255)
+  firstName        String                @db.VarChar(100)
+  lastName         String                @db.VarChar(100)
+  companyName      String                @db.VarChar(225)
+  phoneCountryCode String?               @db.VarChar(5) // e.g., "+1", "+44"
+  phoneNumber      String?               @db.VarChar(15) // National number without country code
+  status           PreVerificationStatus @default(PENDING)
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
+}


### PR DESCRIPTION
## Description

Add Schema for `PreVerification` table  to do this i followed the following steps



## Making DB Change
1. update model in `schema.prisma` file
2. generate migration using  `pnpx prisma migrate dev --name change_table_name`
3. Check status of migration with `pnpx prisma migrate status`
4. Run: `pnpx prisma migrate deploy` to update schema

## Confirm schema locally run 
1.  `psql -h 127.0.0.1 -p 54322 -U postgres -d postgres` to connect as postgres user
2. enter password usually postgres
3. run `\dt` command

<img width="1792" height="459" alt="Screenshot 2025-12-21 at 21 42 55" src="https://github.com/user-attachments/assets/f1f54108-56de-4ef7-85cf-d33039f8487b" />
