### PR TITLE
Fix wrong `https` redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name localhost api.envoye.co;
+    server_name api.envoye.co localhost;
 
 
     location /.well-known/acme-challenge/ {


### PR DESCRIPTION
### Description

In prod, going to http://api.envoye.co/ redirects to localhost 👇 

<img width="1784" height="1080" alt="Screenshot 2025-12-28 at 19 05 21" src="https://github.com/user-attachments/assets/0381694c-c65f-44eb-af9c-a19bca0e23c5" />

 https://api.envoye.co/ works okay 👇 


<img width="1792" height="575" alt="Screenshot 2025-12-28 at 19 06 37" src="https://github.com/user-attachments/assets/f9a041a6-06fe-42e0-ad9b-7278d3833509" />
