### PR TITLE
Do not deploy changes to `prisma`, `gitignore` and `md` files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,14 @@
 name: Deploy to Lightsail
 
 on:
-  push:
-    branches:
-      - main
-
+    push:
+      branches:
+        - main
+      paths-ignore:
+        - 'prisma/schemas/**'
+        - 'prisma/migrations/**'
+        - '.gitignore'
+        - '**.md'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

We don't want to deploy to the server when we make changes to migrations (these are usually standalone changes), documentation, or gitignore folders.

🤔 The idea here is we'd typically want to deploy only changes that directly impact user or security paths. 