### PR TITLE
Default admins username to `firstname.lastName`

### DIFF
--- a/src/workspace/steps/create-workspace-admin.spec.ts
+++ b/src/workspace/steps/create-workspace-admin.spec.ts
@@ -62,13 +62,18 @@ describe('CreateWorkspaceAdminStep', () => {
     );
     await step.execute(workspaceDetails);
 
-    expect(
-      await prismaService.teammate.count({
-        where: {
+    const createdTeammate = await prismaService.teammate.findUniqueOrThrow({
+      where: {
+        workspaceCode_email: {
+          workspaceCode: workspaceDetails.code,
           email: workspaceDetails.pointOfContact.email,
         },
-      }),
-    ).toBe(1);
+      },
+    });
+
+    expect(createdTeammate.username).toBe(
+      `${workspaceDetails.pointOfContact.firstName.toLowerCase()} ${workspaceDetails.pointOfContact.lastName.toLowerCase()}`,
+    );
 
     await step.compensate(workspaceDetails);
 

--- a/src/workspace/steps/create-workspace-admin.ts
+++ b/src/workspace/steps/create-workspace-admin.ts
@@ -15,6 +15,7 @@ export class CreateWorkspaceAdminStep implements PostSetupStep {
         email: pointOfContact.email,
         firstName: pointOfContact.firstName,
         lastName: pointOfContact.lastName,
+        username: `${pointOfContact.firstName.toLowerCase()} ${pointOfContact.lastName.toLowerCase()}`,
         workspaceCode: workspaceDetails.code,
         groups: [ROLES.WorkspaceAdmin.code],
       },


### PR DESCRIPTION
## Sumary

We default the first admin's username to `firstname.lastname` 🤔 We'll give them the option to update it later on. It seems to me like the fastest change. If not, we'll have to update the preverification flow. 


We can also leave it as blank, but that means we'll have to write code to provide you with a way to update it when you first log in. 


🤔 Should make username unique for workspace?