### PR TITLE
Refactor Workspace Test setup

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -19,12 +19,13 @@ import ValidationErrorResponseDto from '@/common/dto/validation-error.dto';
 import preVerificationFactory from '@/factories/roadmap/preverification.factory';
 import Factory, { PersistStrategy } from '@/factories/factory';
 import { WorkspaceLinkService } from '@/workspace/workspace-link.service';
-import { WorkspaceManager } from '@/workspace/workspace-manager.service';
-import { MessagingModule } from '@/messaging/messaging.module';
 import { setupWorkspaceWithTeammate } from '@/test-helpers/workspace-helpers';
 import teammateFactory from '@/factories/teammate.factory';
-import { RoleService } from '@/permission/role/role.service';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
+import {
+  workspaceManagerTestingProvider,
+  createMockEmailClient,
+} from '@/auth/test-utils/auth.module.test-setup';
 
 describe('AuthController', () => {
   let app: INestApplication;
@@ -45,8 +46,9 @@ describe('AuthController', () => {
 
   beforeEach(async () => {
     mockSupabaseClient = createMockSupabaseClient();
+    const mockEmailClient = createMockEmailClient();
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ConfigModule.forRoot(), MessagingModule], // Add ConfigModule for setupApp to work
+      imports: [ConfigModule.forRoot()], // Add ConfigModule for setupApp to work
       controllers: [AuthController],
       providers: [
         AuthService,
@@ -57,9 +59,8 @@ describe('AuthController', () => {
         },
         PrismaService,
         WorkspaceLinkService,
-        WorkspaceManager,
         WorkspaceInviteService,
-        RoleService,
+        workspaceManagerTestingProvider(mockEmailClient),
       ],
     }).compile();
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -6,34 +6,35 @@ import {
   MockSupabaseClient,
 } from './test-utils/supabase.mock';
 import PasswordGenerator from './services/password.generator';
-import { ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { PrismaService } from '@/prisma/prisma.service';
 import { WorkspaceLinkService } from '@/workspace/workspace-link.service';
-import { WorkspaceManager } from '@/workspace/workspace-manager.service';
-import { MessagingModule } from '@/messaging/messaging.module';
-import { RoleService } from '@/permission/role/role.service';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
+import {
+  workspaceManagerTestingProvider,
+  createMockEmailClient,
+} from '@/auth/test-utils/auth.module.test-setup';
 
 describe('AuthService', () => {
   let service: AuthService;
-  const mockSupabaseClient: MockSupabaseClient = createMockSupabaseClient();
+  let mockSupabaseClient: MockSupabaseClient;
 
   beforeEach(async () => {
+    mockSupabaseClient = createMockSupabaseClient();
+    const mockEmailClient = createMockEmailClient();
     const module: TestingModule = await Test.createTestingModule({
-      imports: [MessagingModule],
+      imports: [ConfigModule.forRoot()],
       providers: [
         AuthService,
         PasswordGenerator,
-        ConfigService,
         {
           provide: SupabaseClient,
-          useValue: mockSupabaseClient,
+          useValue: mockSupabaseClient as unknown as SupabaseClient,
         },
         PrismaService,
         WorkspaceLinkService,
-        WorkspaceManager,
         WorkspaceInviteService,
-        RoleService,
+        workspaceManagerTestingProvider(mockEmailClient),
       ],
     }).compile();
 

--- a/src/auth/test-utils/auth.module.test-setup.ts
+++ b/src/auth/test-utils/auth.module.test-setup.ts
@@ -1,0 +1,45 @@
+import { type EmailClient } from '@/messaging/email/email-client';
+import { PrismaService } from '@/prisma/prisma.service';
+import { RoleService } from '@/permission/role/role.service';
+import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
+import { WorkspaceLinkService } from '@/workspace/workspace-link.service';
+import { WorkspaceManager } from '@/workspace/workspace-manager.service';
+
+export function createMockEmailClient(): EmailClient {
+  return {
+    send: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+export function useWorkspaceManagerFactory(
+  mockEmailClient: EmailClient,
+  prismaService: PrismaService,
+  workspaceLinkService: WorkspaceLinkService,
+  workspaceInviteService: WorkspaceInviteService,
+): WorkspaceManager {
+  return new WorkspaceManager(
+    prismaService,
+    mockEmailClient,
+    workspaceLinkService,
+    new RoleService(),
+    workspaceInviteService,
+  );
+}
+
+export function workspaceManagerTestingProvider(mockEmailClient: EmailClient) {
+  return {
+    provide: WorkspaceManager,
+    useFactory: (
+      prismaService: PrismaService,
+      workspaceLinkService: WorkspaceLinkService,
+      workspaceInviteService: WorkspaceInviteService,
+    ) =>
+      useWorkspaceManagerFactory(
+        mockEmailClient,
+        prismaService,
+        workspaceLinkService,
+        workspaceInviteService,
+      ),
+    inject: [PrismaService, WorkspaceLinkService, WorkspaceInviteService],
+  };
+}

--- a/src/workspace/workspace.module.ts
+++ b/src/workspace/workspace.module.ts
@@ -4,11 +4,13 @@ import { WorkspaceController } from './workspace.controller';
 import { WorkspaceLinkService } from '@/workspace/workspace-link.service';
 import { PermissionModule } from '@/permission/permission.module';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { MessagingModule } from '@/messaging/messaging.module';
 
 @Module({
-  imports: [PermissionModule],
+  imports: [PermissionModule, PrismaModule, MessagingModule],
   providers: [WorkspaceManager, WorkspaceLinkService, WorkspaceInviteService],
   controllers: [WorkspaceController],
-  exports: [WorkspaceManager, WorkspaceLinkService, WorkspaceInviteService],
+  exports: [WorkspaceLinkService, WorkspaceManager],
 })
 export class WorkspaceModule {}


### PR DESCRIPTION
### Summary

I this PR i am attempting to make the dependency tree in test pretty obvious.  For both our sanity and maintanability

The problem here is just looking at the  provider here 👇  it is not immediately obvious why we need RoleService. 


```javascript
 providers: [
        AuthService,
        PasswordGenerator,
        ConfigService,
        {
          provide: SupabaseClient,
          useValue: mockSupabaseClient,
        },
        PrismaService,
        WorkspaceLinkService,
        WorkspaceManager,
        WorkspaceInviteService,
        RoleService,
      ],
```


Doing this makes it clear that it's one of the things workspaceManager needs to be instantiated. 

```javascript
  return {
    provide: WorkspaceManager,
    useFactory: (
      prismaService: PrismaService,
      workspaceLinkService: WorkspaceLinkService,
      workspaceInviteService: WorkspaceInviteService,
    ) =>
      useWorkspaceManagerFactory(
        mockEmailClient,
        prismaService,
        workspaceLinkService,
        workspaceInviteService,
      ),
    inject: [PrismaService, WorkspaceLinkService, WorkspaceInviteService],
  };
}
```


I do admit that this seems like a lot of work upfront while setting up, but it makes debugging really stress free.

