### PR TITLE
Protect workspace detail route

### DIFF
--- a/src/common/link-service.ts
+++ b/src/common/link-service.ts
@@ -17,10 +17,6 @@ export class LinkService {
     return `${this.siteUrl}/setup/${preverificationId}/workspace`;
   }
 
-  workspaceUrl(workspaceCode: string): string {
-    return `${this.siteUrl}/workspace?code=${workspaceCode}`;
-  }
-
   private get siteUrl(): string {
     return this.configService.get<string>('SITE_URL', '');
   }

--- a/src/common/link-service.ts
+++ b/src/common/link-service.ts
@@ -17,6 +17,10 @@ export class LinkService {
     return `${this.siteUrl}/setup/${preverificationId}/workspace`;
   }
 
+  workspaceUrl(workspaceCode: string): string {
+    return `${this.siteUrl}/workspace?code=${workspaceCode}`;
+  }
+
   private get siteUrl(): string {
     return this.configService.get<string>('SITE_URL', '');
   }

--- a/src/permission/permission.service.ts
+++ b/src/permission/permission.service.ts
@@ -3,7 +3,7 @@ import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { isEmpty } from '@/common/utils';
 import { RoleService } from './role/role.service';
 import RequestUser from '@/auth/domain/request-user';
-import { Teammate } from '@/generated/prisma/client';
+import { Teammate, TeammateStatus } from '@/generated/prisma/client';
 import { Permission } from '@/permission/domain/permission';
 
 @Injectable()
@@ -63,7 +63,7 @@ export class PermissionService {
     }
   }
 
-  private async findWorkspaceMember(
+  private async findActiveWorkspaceMember(
     email: string,
     workspaceCode: string,
   ): Promise<Teammate | null> {
@@ -71,17 +71,19 @@ export class PermissionService {
       where: {
         workspaceCode: workspaceCode,
         email: email,
+        status: TeammateStatus.ACTIVE,
       },
     });
   }
 
-  async runIfWorkspaceMemberAndPermitted<T>(
+
+  async runIfActiveWorkspaceMemberAndPermitted<T>(
     requestUser: RequestUser,
     workspaceCode: string,
     requiredPermission: Permission,
     authorizedAction: (teammate: Teammate) => T,
   ) {
-    const workspaceMember = await this.findWorkspaceMember(
+    const workspaceMember = await this.findActiveWorkspaceMember(
       requestUser.email,
       workspaceCode,
     );
@@ -102,12 +104,12 @@ export class PermissionService {
     }
   }
 
-  async runIfWorkspaceMember<T>(
+  async runIfActiveWorkspaceMember<T>(
     requestUser: RequestUser,
     workspaceCode: string,
     authorizedAction: (teammate: Teammate) => T,
   ) {
-    const workspaceTeammate = await this.findWorkspaceMember(
+    const workspaceTeammate = await this.findActiveWorkspaceMember(
       requestUser.email,
       workspaceCode,
     );

--- a/src/permission/permission.service.ts
+++ b/src/permission/permission.service.ts
@@ -63,20 +63,29 @@ export class PermissionService {
     }
   }
 
+  private async findWorkspaceMember(
+    email: string,
+    workspaceCode: string,
+  ): Promise<Teammate | null> {
+    return this.prismaService.teammate.findFirst({
+      where: {
+        workspaceCode: workspaceCode,
+        email: email,
+      },
+    });
+  }
+
   async runIfWorkspaceMemberAndPermitted<T>(
     requestUser: RequestUser,
     workspaceCode: string,
     requiredPermission: Permission,
     authorizedAction: (teammate: Teammate) => T,
   ) {
-    const isWorkspaceMember = await this.prismaService.teammate.findFirst({
-      where: {
-        workspaceCode: workspaceCode,
-        email: requestUser.email,
-      },
-    });
-
-    if (isWorkspaceMember) {
+    const workspaceMember = await this.findWorkspaceMember(
+      requestUser.email,
+      workspaceCode,
+    );
+    if (workspaceMember) {
       return await this.runIfPermitted(
         requestUser,
         workspaceCode,
@@ -91,5 +100,24 @@ export class PermissionService {
       );
       throw new ForbiddenException();
     }
+  }
+
+  async runIfWorkspaceMember<T>(
+    requestUser: RequestUser,
+    workspaceCode: string,
+    authorizedAction: (teammate: Teammate) => T,
+  ) {
+    const workspaceTeammate = await this.findWorkspaceMember(
+      requestUser.email,
+      workspaceCode,
+    );
+
+    if (workspaceTeammate) {
+      return authorizedAction(workspaceTeammate);
+    }
+    //TODO: add metric here or envoye alert to message us
+    // TODO: write the attempt into the db  and log id of atttmept. let attempt contain user email.
+    this.logger.log('Tried to access workspace without permission');
+    throw new ForbiddenException();
   }
 }

--- a/src/permission/permission.service.ts
+++ b/src/permission/permission.service.ts
@@ -76,7 +76,6 @@ export class PermissionService {
     });
   }
 
-
   async runIfActiveWorkspaceMemberAndPermitted<T>(
     requestUser: RequestUser,
     workspaceCode: string,

--- a/src/teammates/teammates.controller.ts
+++ b/src/teammates/teammates.controller.ts
@@ -56,7 +56,7 @@ export class TeammatesController {
     @User() requestUser: RequestUser,
     @Query('workspaceCode') workspaceCode: string,
   ): Promise<TeammateResponseDto[]> {
-    return await this.permissionService.runIfWorkspaceMemberAndPermitted(
+    return await this.permissionService.runIfActiveWorkspaceMemberAndPermitted(
       requestUser,
       workspaceCode,
       PERMISSIONS.MANAGE_TEAMMATES,

--- a/src/workspace/workspace.controller.spec.ts
+++ b/src/workspace/workspace.controller.spec.ts
@@ -143,6 +143,13 @@ describe('WorkspaceController', () => {
       const workspace = await factory.persist('workspace', () =>
         workspaceFactory.build({ code: 'abc123', name: 'Test Workspace' }),
       );
+      await factory.persist('teammate', () =>
+        teammateFactory.build({
+          email: requestUser.email,
+          workspaceCode: workspace.code,
+          groups: [ROLES.WorkspaceAdmin.code],
+        }),
+      );
 
       const response = await request(getHttpServer(app))
         .get(AuthEndpoints.WORKSPACE_DETAILS)
@@ -158,13 +165,33 @@ describe('WorkspaceController', () => {
       });
     });
 
-    it('returns 404 when workspace does not exist', async () => {
+    it('returns 403 when workspace does not exist', async () => {
       await request(getHttpServer(app))
         .get(AuthEndpoints.WORKSPACE_DETAILS)
         .query({ code: 'nonex1' })
         .set('Accept', 'application/json')
         .set('Authorization', 'Bearer test-token')
-        .expect(HttpStatus.NOT_FOUND);
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it('returns 403 when user is not a member of the workspace', async () => {
+      const workspace = await factory.persist('workspace', () =>
+        workspaceFactory.build({ code: 'othr01', name: 'Other Workspace' }),
+      );
+      await factory.persist('teammate', () =>
+        teammateFactory.build({
+          email: 'colleague@example.com',
+          workspaceCode: workspace.code,
+          groups: [ROLES.WorkspaceAdmin.code],
+        }),
+      );
+
+      await request(getHttpServer(app))
+        .get(AuthEndpoints.WORKSPACE_DETAILS)
+        .query({ code: workspace.code })
+        .set('Accept', 'application/json')
+        .set('Authorization', 'Bearer test-token')
+        .expect(HttpStatus.FORBIDDEN);
     });
   });
 

--- a/src/workspace/workspace.controller.spec.ts
+++ b/src/workspace/workspace.controller.spec.ts
@@ -11,6 +11,7 @@ import {
   InviteStatus,
   PreVerification,
   PreVerificationStatus,
+  TeammateStatus,
   Workspace,
 } from '@/generated/prisma/client';
 import preVerificationFactory from '@/factories/roadmap/preverification.factory';
@@ -148,6 +149,7 @@ describe('WorkspaceController', () => {
           email: requestUser.email,
           workspaceCode: workspace.code,
           groups: [ROLES.WorkspaceAdmin.code],
+          status: TeammateStatus.ACTIVE,
         }),
       );
 
@@ -183,6 +185,7 @@ describe('WorkspaceController', () => {
           email: 'colleague@example.com',
           workspaceCode: workspace.code,
           groups: [ROLES.WorkspaceAdmin.code],
+          status: TeammateStatus.ACTIVE,
         }),
       );
 
@@ -193,6 +196,42 @@ describe('WorkspaceController', () => {
         .set('Authorization', 'Bearer test-token')
         .expect(HttpStatus.FORBIDDEN);
     });
+
+    it.each([
+      {
+        workspaceCode: 'disab1',
+        status: TeammateStatus.DISABLED,
+      },
+      {
+        workspaceCode: 'deltd1',
+        status: TeammateStatus.DELETED,
+      },
+    ])(
+      'returns 403 Forbidden when user is not an active workspace member (status $status)',
+      async ({ workspaceCode, status }) => {
+        const workspace = await factory.persist('workspace', () =>
+          workspaceFactory.build({
+            code: workspaceCode,
+            name: 'Non-active member WS',
+          }),
+        );
+        await factory.persist('teammate', () =>
+          teammateFactory.build({
+            email: requestUser.email,
+            workspaceCode: workspace.code,
+            groups: [ROLES.WorkspaceAdmin.code],
+            status,
+          }),
+        );
+
+        await request(getHttpServer(app))
+          .get(AuthEndpoints.WORKSPACE_DETAILS)
+          .query({ code: workspace.code })
+          .set('Accept', 'application/json')
+          .set('Authorization', 'Bearer test-token')
+          .expect(HttpStatus.FORBIDDEN);
+      },
+    );
   });
 
   describe(' Invite Teammates', () => {

--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -107,9 +107,16 @@ export class WorkspaceController {
     description: 'Workspace not found',
   })
   @UseGuards(SupabaseAuthGuard)
-  async getByCode(@Query('code') code: string): Promise<WorkspaceResponseDto> {
+  async getByCode(
+    @User() requestUser: RequestUser,
+    @Query('code') code: string,
+  ): Promise<WorkspaceResponseDto> {
     try {
-      return await this.workspaceManager.details(code);
+      return await this.permissionService.runIfWorkspaceMember(
+        requestUser,
+        code,
+        async () => await this.workspaceManager.details(code),
+      );
     } catch (error) {
       if (error instanceof NotFoundInDb) {
         throw new NotFoundException();

--- a/src/workspace/workspace.controller.ts
+++ b/src/workspace/workspace.controller.ts
@@ -112,7 +112,7 @@ export class WorkspaceController {
     @Query('code') code: string,
   ): Promise<WorkspaceResponseDto> {
     try {
-      return await this.permissionService.runIfWorkspaceMember(
+      return await this.permissionService.runIfActiveWorkspaceMember(
         requestUser,
         code,
         async () => await this.workspaceManager.details(code),


### PR DESCRIPTION
## Summary

Previously, it was possible that teammate who wasn't a member of workspace could get workspace details. 🤔 we think it's better to not let cross workspace information as this could be security issue. To avoid this we check that teammate is active member of workspace before allowing fetch. 