### PR TITLE
Use registered domain for email

### DIFF
--- a/src/workspace/workspace-manager.service.ts
+++ b/src/workspace/workspace-manager.service.ts
@@ -324,7 +324,7 @@ export class WorkspaceManager {
       );
 
       await this.emailClient.send({
-        from: { email: sender.email, name: sender.firstName },
+        from: { email: 'invite@envoye.co', name: sender.firstName },
         to: { email: recipientEmail, name: '' },
         subject: 'Workspace Invite',
         html: emailHtml,


### PR DESCRIPTION
## Summary

From prod logs, we see error 👇 it seems it's cause we are trying to send from a non-registered domain

<img width="653" height="244" alt="Screenshot 2026-04-11 at 23 24 20" src="https://github.com/user-attachments/assets/f78f7dbc-2d2e-4cd8-9d3d-a5847135bff9" />
