### PR TITLE
Update Fetch Teammate Permission

### DIFF
--- a/src/permission/types.ts
+++ b/src/permission/types.ts
@@ -26,7 +26,7 @@ export const PERMISSIONS = {
     'Connect Messaging Platforms',
     'Allows user to connect supported messaging platforms, like whatsapp etc',
     'manage_channels',
-  )
+  ),
 } as const;
 
 export const ROLES: Record<string, Role> = {

--- a/src/permission/types.ts
+++ b/src/permission/types.ts
@@ -26,12 +26,7 @@ export const PERMISSIONS = {
     'Connect Messaging Platforms',
     'Allows user to connect supported messaging platforms, like whatsapp etc',
     'manage_channels',
-  ),
-  VIEW_TEAMMATES: Permission.of(
-    'View Workspace Teammates',
-    'Allows user to view teammates in workspace',
-    'view_teammates',
-  ),
+  )
 } as const;
 
 export const ROLES: Record<string, Role> = {
@@ -40,14 +35,12 @@ export const ROLES: Record<string, Role> = {
     PERMISSIONS.REPLY_SUPPORT_CONVERSATIONS,
     PERMISSIONS.MESSAGE_TEAMMATES,
     PERMISSIONS.MANAGE_TEAMMATES,
-    PERMISSIONS.VIEW_TEAMMATES,
     PERMISSIONS.MANAGE_CHANNELS,
   ]),
   SupportStaff: Role.of('SupportStaff', [
     PERMISSIONS.READ_SUPPORT_CONVERSATIONS,
     PERMISSIONS.REPLY_SUPPORT_CONVERSATIONS,
     PERMISSIONS.MESSAGE_TEAMMATES,
-    PERMISSIONS.VIEW_TEAMMATES,
   ]),
   WorkspaceMember: Role.of('WorkspaceMember', [PERMISSIONS.MESSAGE_TEAMMATES]),
 };

--- a/src/permission/types.ts
+++ b/src/permission/types.ts
@@ -27,6 +27,11 @@ export const PERMISSIONS = {
     'Allows user to connect supported messaging platforms, like whatsapp etc',
     'manage_channels',
   ),
+  VIEW_TEAMMATES: Permission.of(
+    'View Workspace Teammates',
+    'Allows user to view teammates in workspace',
+    'view_teammates',
+  ),
 } as const;
 
 export const ROLES: Record<string, Role> = {
@@ -35,12 +40,14 @@ export const ROLES: Record<string, Role> = {
     PERMISSIONS.REPLY_SUPPORT_CONVERSATIONS,
     PERMISSIONS.MESSAGE_TEAMMATES,
     PERMISSIONS.MANAGE_TEAMMATES,
+    PERMISSIONS.VIEW_TEAMMATES,
     PERMISSIONS.MANAGE_CHANNELS,
   ]),
   SupportStaff: Role.of('SupportStaff', [
     PERMISSIONS.READ_SUPPORT_CONVERSATIONS,
     PERMISSIONS.REPLY_SUPPORT_CONVERSATIONS,
     PERMISSIONS.MESSAGE_TEAMMATES,
+    PERMISSIONS.VIEW_TEAMMATES,
   ]),
   WorkspaceMember: Role.of('WorkspaceMember', [PERMISSIONS.MESSAGE_TEAMMATES]),
 };

--- a/src/teammates/dto/teammate-response.dto.ts
+++ b/src/teammates/dto/teammate-response.dto.ts
@@ -15,8 +15,14 @@ export class TeammateResponseDto {
   @ApiProperty({ description: 'Teammate last name' })
   lastName: string;
 
+  @ApiProperty({ description: 'Teammate username' })
+  username: string;
+
   @ApiProperty({ description: 'Teammate status', enum: TeammateStatus })
   status: TeammateStatus;
+
+  @ApiProperty({ description: 'Teammate role' })
+  role: string;
 
   @ApiProperty({ description: 'Teammate avatar url', nullable: true })
   avatarUrl: string | null;
@@ -26,11 +32,14 @@ export class TeammateResponseDto {
 }
 
 export function toTeammateResponse(teammate: Teammate): TeammateResponseDto {
+  const roles = teammate.groups ?? [];
   return {
     id: teammate.id,
     email: teammate.email,
     firstName: teammate.firstName,
     lastName: teammate.lastName,
+    username: teammate.username ?? 'unknown',
+    role: roles[0],
     status: teammate.status,
     avatarUrl: teammate.avatarUrl,
     groups: teammate.groups,

--- a/src/teammates/teammates.controller.ts
+++ b/src/teammates/teammates.controller.ts
@@ -61,7 +61,7 @@ export class TeammatesController {
     return await this.permissionService.runIfActiveWorkspaceMemberAndPermitted(
       requestUser,
       workspaceCode,
-      PERMISSIONS.MANAGE_TEAMMATES,
+      PERMISSIONS.VIEW_TEAMMATES,
       async () => {
         const teammates = await this.teammatesService.getTeammates(
           workspaceCode,

--- a/src/teammates/teammates.controller.ts
+++ b/src/teammates/teammates.controller.ts
@@ -17,7 +17,6 @@ import {
 import { User } from '@/auth/decorator/user.decorator';
 import RequestUser from '@/auth/domain/request-user';
 import { PermissionService } from '@/permission/permission.service';
-import { PERMISSIONS } from '@/permission/types';
 import { TeammateStatus } from '@/generated/prisma/enums';
 import { CheckUsernameQueryDto } from '@/teammates/dto/check-username-query.dto';
 

--- a/src/teammates/teammates.controller.ts
+++ b/src/teammates/teammates.controller.ts
@@ -58,10 +58,9 @@ export class TeammatesController {
     @User() requestUser: RequestUser,
     @Query('workspaceCode') workspaceCode: string,
   ): Promise<TeammateResponseDto[]> {
-    return await this.permissionService.runIfActiveWorkspaceMemberAndPermitted(
+    return await this.permissionService.runIfActiveWorkspaceMember(
       requestUser,
       workspaceCode,
-      PERMISSIONS.VIEW_TEAMMATES,
       async () => {
         const teammates = await this.teammatesService.getTeammates(
           workspaceCode,


### PR DESCRIPTION
## Summary

We put fetch teammate behind a new permission. 🤔 It makes sense to use that as long as you are a workspace member, you should be able to fetch all members of the workspace you belong to. 