### PR TITLE
Bump up docker actions to use node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 24.x
 
       - name: Setup Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login To Docker Hub
         uses: docker/login-action@v4
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build And Push Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
### Summary

CI actions will soon stop supporting node 20, so we need to bump this up 

<img width="1448" height="666" alt="Screenshot 2026-04-21 at 21 30 19" src="https://github.com/user-attachments/assets/8de61cd3-cc7b-4876-b170-b1378b8d029a" />
