### PR TITLE
ft: added `normalizedusername` to `teammates` schema

### DIFF
--- a/prisma/migrations/20260422115909_add_normalized_username_to_teammate/migration.sql
+++ b/prisma/migrations/20260422115909_add_normalized_username_to_teammate/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "teammate" ADD COLUMN     "normalizedUsername" VARCHAR(50);

--- a/prisma/schemas/teammate.prisma
+++ b/prisma/schemas/teammate.prisma
@@ -5,19 +5,20 @@ enum TeammateStatus {
 }
 
 model Teammate {
-  id               Int               @id @default(autoincrement())
-  email            String            @db.VarChar(255)
-  firstName        String            @db.VarChar(100)
-  lastName         String            @db.VarChar(100)
-  username         String?           @db.VarChar(50)
-  workspaceCode    String            @db.VarChar(6)
-  workspace        Workspace         @relation(fields: [workspaceCode], references: [code], onDelete: Cascade)
-  status           TeammateStatus    @default(ACTIVE)
-  avatarUrl        String?           @db.VarChar(600)
-  groups           String[]          @default([])
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
-  workspaceInvites WorkspaceInvite[]
+  id                 Int               @id @default(autoincrement())
+  email              String            @db.VarChar(255)
+  firstName          String            @db.VarChar(100)
+  lastName           String            @db.VarChar(100)
+  username           String?           @db.VarChar(50)
+  normalizedUsername String?           @db.VarChar(50)
+  workspaceCode      String            @db.VarChar(6)
+  workspace          Workspace         @relation(fields: [workspaceCode], references: [code], onDelete: Cascade)
+  status             TeammateStatus    @default(ACTIVE)
+  avatarUrl          String?           @db.VarChar(600)
+  groups             String[]          @default([])
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+  workspaceInvites   WorkspaceInvite[]
 
   @@unique([workspaceCode, email])
   @@unique([workspaceCode, username])

--- a/src/factories/teammate.factory.ts
+++ b/src/factories/teammate.factory.ts
@@ -13,12 +13,14 @@ class TeammateFactory extends Factory<Teammate> {
 const teammateFactory = TeammateFactory.define(({ sequence }) => {
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
+  const username = `${firstName}.${lastName}`;
   return {
     id: sequence,
     email: faker.internet.email(),
     firstName: firstName,
     lastName: lastName,
-    username: `${firstName}.${lastName}`,
+    username: username,
+    normalizedUsername: username.split('.').join(''),
     workspaceCode: sixCharHumanFriendlyCode(),
     status: TeammateStatus.ACTIVE,
     avatarUrl: faker.internet.url(),


### PR DESCRIPTION
- added `normalizedusername` to `teammates` schema for checking of username uniqueness.
- when we get `laura.ajoku` and `laur.aajoku` as usernames from different teammates, we want to identify them as the same, because normalized, they both are `lauraajoku`