### PR TITLE
Explicitly allow builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine AS builder
 WORKDIR /src
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 COPY . .
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "build": "nest build",
     "check:format": "prettier --check \"src/**/*.{ts,tsx}\" \"test/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
-  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "build": "nest build",
     "check:format": "prettier --check \"src/**/*.{ts,tsx}\" \"test/**/*.ts\"",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,14 @@
+allowBuilds:
+  '@nestjs/core': false
+  '@prisma/engines': false
+  '@scarf/scarf': false
+  cpu-features: false
+  esbuild: false
+  prisma: false
+  protobufjs: false
+  sharp: false
+  ssh2: false
+  supabase: true
+  unrs-resolver: false
 onlyBuiltDependencies:
   - supabase


### PR DESCRIPTION
## Summary

🤔 I'm guessing due to recent supply chain attacks, the package manager became a bit stricter. We have to explicitly specify packages where we want to run post-install scripts, or the build will fail. We have to update CI, to allow for this change so we can build in prod. 