### PR TITLE
Add endpoint to return app and feature enablement

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -405,7 +405,10 @@ describe('AdminController', () => {
 
   describe('List app enrollment', () => {
     it('returns all apps with hasFeature for SuperAdmin', async () => {
-      await setupSuperAdmin(factory, requestUser.email);
+      const { workspace: envoye } = await setupSuperAdmin(
+        factory,
+        requestUser.email,
+      );
       const featureFlag = await factory.persist('featureFlag', () =>
         featureFlagFactory.build({ status: FeatureFlagStatus.PARTIAL }),
       );
@@ -431,7 +434,7 @@ describe('AdminController', () => {
         .set('Authorization', 'Bearer test-token')
         .expect(HttpStatus.OK);
 
-      expect(response.body).toHaveLength(2);
+      expect(response.body).toHaveLength(3);
       expect(response.body).toEqual(
         expect.arrayContaining([
           {
@@ -446,6 +449,13 @@ describe('AdminController', () => {
             appCode: zuriBakery.code,
             name: 'Zuri Bakery',
             status: zuriBakery.status,
+            hasFeature: false,
+          },
+          {
+            appId: envoye.id,
+            appCode: envoye.code,
+            name: envoye.name,
+            status: envoye.status,
             hasFeature: false,
           },
         ]),

--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -403,6 +403,86 @@ describe('AdminController', () => {
     });
   });
 
+  describe('List app enrollment', () => {
+    it('returns all apps with hasFeature for SuperAdmin', async () => {
+      await setupSuperAdmin(factory, requestUser.email);
+      const featureFlag = await factory.persist('featureFlag', () =>
+        featureFlagFactory.build({ status: FeatureFlagStatus.PARTIAL }),
+      );
+      const koboMart = await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Kobo Mart' }),
+      );
+      const zuriBakery = await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Zuri Bakery' }),
+      );
+
+      await request(getHttpServer(app))
+        .post('/admin/feature-flag/enable-apps')
+        .set('Authorization', 'Bearer test-token')
+        .send({
+          key: featureFlag.key,
+          appCodes: [koboMart.code],
+        })
+        .expect(HttpStatus.OK);
+
+      const response = await request(getHttpServer(app))
+        .get('/admin/feature-flag/apps/enrollment')
+        .query({ featureKey: featureFlag.key })
+        .set('Authorization', 'Bearer test-token')
+        .expect(HttpStatus.OK);
+
+      expect(response.body).toHaveLength(2);
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          {
+            appId: koboMart.id,
+            appCode: koboMart.code,
+            name: 'Kobo Mart',
+            status: koboMart.status,
+            hasFeature: true,
+          },
+          {
+            appId: zuriBakery.id,
+            appCode: zuriBakery.code,
+            name: 'Zuri Bakery',
+            status: zuriBakery.status,
+            hasFeature: false,
+          },
+        ]),
+      );
+    });
+
+    it('returns 403 when user lacks permission', async () => {
+      await setupWorkspaceWithTeammate(
+        factory,
+        teammateFactory.build({
+          email: requestUser.email,
+          workspaceCode: ENVOYE_WORKSPACE_CODE,
+          groups: [ROLES.WorkspaceAdmin.code],
+        }),
+      );
+      const featureFlag = await factory.persist('featureFlag', () =>
+        featureFlagFactory.build({ status: FeatureFlagStatus.PARTIAL }),
+      );
+
+      await request(getHttpServer(app))
+        .get('/admin/feature-flag/apps/enrollment')
+        .query({ featureKey: featureFlag.key })
+        .set('Authorization', 'Bearer test-token')
+        .expect(HttpStatus.FORBIDDEN);
+    });
+
+    it('returns 404 for unknown feature key', async () => {
+      await setupSuperAdmin(factory, requestUser.email);
+
+      await request(getHttpServer(app))
+        .get('/admin/feature-flag/apps/enrollment')
+        .query({ featureKey: 'nonexistent_flag' })
+        .set('Authorization', 'Bearer test-token')
+        .expect(HttpStatus.NOT_FOUND);
+    });
+  });
+
   describe('List apps', () => {
     it('returns apps for SuperAdmin', async () => {
       await setupSuperAdmin(factory, requestUser.email);

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -20,12 +20,14 @@ import {
 } from '@nestjs/swagger';
 import FeatureFlagDto, {
   AppDto,
+  AppEnrollmentDto,
   CreateFeatureFlagDto,
   DeleteFeatureFlagDto,
   EnableFeatureForAppsDto,
   GetFeatureEnabledAppsQueryDto,
   PatchFeatureFlagStatusDto,
   toAppDto,
+  toAppEnrollmentDto,
   toFeatureFlagDto,
 } from '@/admin/dto/feature-flag.dto';
 import { SupabaseAuthGuard } from '@/auth/guard/supabase.guard';
@@ -217,6 +219,51 @@ export class AdminController {
         ENVOYE_WORKSPACE_CODE,
         PERMISSIONS.MANAGE_FEATURE_FLAGS,
         () => this.featureFlagManager.enableFFForApps(body.key, body.appCodes),
+      );
+    } catch (error) {
+      if (error instanceof NotFoundInDb) {
+        throw new NotFoundException();
+      }
+      throw error;
+    }
+  }
+
+  @Get('/feature-flag/apps/enrollment')
+  @ApiOperation({ summary: 'List all apps with feature enrollment status' })
+  @ApiQuery({
+    name: 'featureKey',
+    description: 'Key of the feature flag',
+    example: 'can_use_whatsapp',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'All apps (up to 100) with hasFeature',
+    type: [AppEnrollmentDto],
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Missing permission or not an active Envoye workspace member',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Feature flag not found',
+  })
+  @UseGuards(SupabaseAuthGuard)
+  async listAppEnrollment(
+    @User() requestUser: RequestUser,
+    @Query() query: GetFeatureEnabledAppsQueryDto,
+  ): Promise<AppEnrollmentDto[]> {
+    try {
+      const appEnrollment =
+        await this.permissionService.runIfActiveWorkspaceMemberAndPermitted(
+          requestUser,
+          ENVOYE_WORKSPACE_CODE,
+          PERMISSIONS.MANAGE_FEATURE_FLAGS,
+          () => this.featureFlagManager.listAppEnrollment(query.featureKey),
+        );
+
+      return appEnrollment.map(({ workspace, hasFeature }) =>
+        toAppEnrollmentDto(workspace, hasFeature),
       );
     } catch (error) {
       if (error instanceof NotFoundInDb) {

--- a/src/admin/dto/feature-flag.dto.ts
+++ b/src/admin/dto/feature-flag.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsArray,
+  IsBoolean,
   IsEnum,
   IsNumber,
   IsString,
@@ -129,6 +130,25 @@ export function toAppDto(workspace: Workspace): AppDto {
     appCode: workspace.code,
     name: workspace.name,
     status: workspace.status,
+  };
+}
+
+export class AppEnrollmentDto extends AppDto {
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Whether the feature is enabled for this app',
+    example: true,
+  })
+  hasFeature: boolean;
+}
+
+export function toAppEnrollmentDto(
+  workspace: Workspace,
+  hasFeature: boolean,
+): AppEnrollmentDto {
+  return {
+    ...toAppDto(workspace),
+    hasFeature,
   };
 }
 

--- a/src/feature-flag/manager.spec.ts
+++ b/src/feature-flag/manager.spec.ts
@@ -391,4 +391,103 @@ describe('FeatureFlagManager', () => {
       ).rejects.toBeInstanceOf(NotFoundInDb);
     });
   });
+
+  describe('listAppEnrollment', () => {
+    it('returns all apps with mixed hasFeature for PARTIAL flag', async () => {
+      const koboMart = await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Kobo Mart' }),
+      );
+      const zuriBakery = await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Zuri Bakery' }),
+      );
+      const featureFlag = await createFeatureFlag(FeatureFlagStatus.PARTIAL);
+
+      await featureFlagManager.enableFFForApps(featureFlag.key, [
+        koboMart.code,
+      ]);
+
+      const appEnrollment = await featureFlagManager.listAppEnrollment(
+        featureFlag.key,
+      );
+
+      expect(appEnrollment).toHaveLength(2);
+      expect(appEnrollment).toEqual(
+        expect.arrayContaining([
+          {
+            workspace: koboMart,
+            hasFeature: true,
+          },
+          {
+            workspace: zuriBakery,
+            hasFeature: false,
+          },
+        ]),
+      );
+    });
+
+    it('returns all apps with hasFeature true for GLOBAL flag', async () => {
+      const koboMart = await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Kobo Mart' }),
+      );
+      const zuriBakery = await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Zuri Bakery' }),
+      );
+      const featureFlag = await createFeatureFlag(FeatureFlagStatus.DISABLED);
+      await featureFlagManager.turnOnFFGlobally(featureFlag.key);
+
+      const appEnrollment = await featureFlagManager.listAppEnrollment(
+        featureFlag.key,
+      );
+
+      expect(appEnrollment).toHaveLength(2);
+      expect(appEnrollment).toEqual(
+        expect.arrayContaining([
+          {
+            workspace: koboMart,
+            hasFeature: true,
+          },
+          {
+            workspace: zuriBakery,
+            hasFeature: true,
+          },
+        ]),
+      );
+    });
+
+    it('returns all apps with hasFeature false for DISABLED flag', async () => {
+      await factory.persist('workspace', () =>
+        workspaceFactory.build({ name: 'Kobo Mart' }),
+      );
+      const featureFlag = await createFeatureFlag(FeatureFlagStatus.DISABLED);
+
+      const appEnrollment = await featureFlagManager.listAppEnrollment(
+        featureFlag.key,
+      );
+
+      expect(appEnrollment).toHaveLength(1);
+      expect(appEnrollment[0].hasFeature).toBe(false);
+    });
+
+    it('returns up to 100 apps', async () => {
+      const companyProfile = await factory.persist('companyProfile', () =>
+        CompanyProfileFactory.build(),
+      );
+      await prismaService.workspace.createMany({
+        data: workspaceFactory.buildList(200, { ownedById: companyProfile.id }),
+      });
+      const featureFlag = await createFeatureFlag(FeatureFlagStatus.DISABLED);
+
+      const appEnrollment = await featureFlagManager.listAppEnrollment(
+        featureFlag.key,
+      );
+
+      expect(appEnrollment).toHaveLength(100);
+    });
+
+    it('throws NotFoundInDb for unknown key', async () => {
+      await expect(
+        featureFlagManager.listAppEnrollment('nonexistent_flag'),
+      ).rejects.toBeInstanceOf(NotFoundInDb);
+    });
+  });
 });

--- a/src/feature-flag/manager.ts
+++ b/src/feature-flag/manager.ts
@@ -268,6 +268,67 @@ export default class FeatureFlagManager {
     });
   }
 
+  async listAppEnrollment(
+    key: string,
+  ): Promise<{ workspace: Workspace; hasFeature: boolean }[]> {
+    try {
+      const featureFlag = await this.prismaService.featureFlag.findFirstOrThrow(
+        {
+          where: { key },
+        },
+      );
+
+      const workspaces = await this.prismaService.workspace.findMany({
+        take: FeatureFlagManager.APPS_WITH_FEATURE_ENABLED_LIMIT,
+        orderBy: { id: 'asc' },
+      });
+
+      switch (featureFlag.status) {
+        case FeatureFlagStatus.DISABLED:
+          return workspaces.map((workspace) => ({
+            workspace,
+            hasFeature: false,
+          }));
+        case FeatureFlagStatus.GLOBAL:
+          return workspaces.map((workspace) => ({
+            workspace,
+            hasFeature: true,
+          }));
+        case FeatureFlagStatus.PARTIAL: {
+          const enrolledWorkspaceCodes = new Set(
+            (
+              await this.prismaService.workspaceFeature.findMany({
+                where: {
+                  featureFlagId: featureFlag.id,
+                  workspaceCode: {
+                    in: workspaces.map((workspace) => workspace.code),
+                  },
+                },
+                select: { workspaceCode: true },
+              })
+            ).map((workspaceFeature) => workspaceFeature.workspaceCode),
+          );
+
+          return workspaces.map((workspace) => ({
+            workspace,
+            hasFeature: enrolledWorkspaceCodes.has(workspace.code),
+          }));
+        }
+        default:
+          throw new UnExpectedStatusException(
+            `Unexpected feature flag status for key "${key}": ${String(
+              featureFlag.status,
+            )}`,
+          );
+      }
+    } catch (error) {
+      if (notInDbError(error)) {
+        throw new NotFoundInDb(`Feature flag not found; key=${key}`);
+      }
+      throw error;
+    }
+  }
+
   async appsWithFeatureEnabled(key: string): Promise<Workspace[]> {
     try {
       const featureFlag = await this.prismaService.featureFlag.findFirstOrThrow(


### PR DESCRIPTION
## Summary

Add a new Endpoint so admin can see app enrollment.

👇 Endpoint powers this

<img width="787" height="453" alt="Screenshot 2026-05-31 at 20 13 47" src="https://github.com/user-attachments/assets/4bc655c9-9991-4b6b-abd3-53f8f901460a" />
