### PR TITLE
Ft/workspace creation self conversation setup

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -25,6 +25,7 @@ import workspaceFactory from '@/factories/workspace.factory';
 import { FeatureFlagStatus } from '@/generated/prisma/enums';
 import { WorkspaceManager } from '@/workspace/workspace-manager.service';
 import { LinkService } from '@/common/link-service';
+import { ConversationsService } from '@/conversations/conversations.service';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
 import { EMAIL_CLIENT } from '@/messaging/email/email-client';
 import { AuthService } from '@/auth/auth.service';
@@ -47,6 +48,7 @@ describe('AdminController', () => {
         WorkspaceManager,
         LinkService,
         WorkspaceInviteService,
+        ConversationsService,
         { provide: EMAIL_CLIENT, useValue: { send: jest.fn() } },
         { provide: AuthService, useValue: mockAuthService },
       ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { CommonModule } from '@/common/common.module';
 import { BackfillModule } from './backfill/backfill.module';
 import { CommandsModule } from '@/commands/commands.module';
 import { AdminModule } from './admin/admin.module';
+import { ConversationsModule } from './conversations/conversations.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { AdminModule } from './admin/admin.module';
     BackfillModule,
     CommandsModule,
     AdminModule,
+    ConversationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/test-utils/auth.module.test-setup.ts
+++ b/src/auth/test-utils/auth.module.test-setup.ts
@@ -4,6 +4,7 @@ import { RoleService } from '@/permission/role/role.service';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
 import { WorkspaceManager } from '@/workspace/workspace-manager.service';
 import { LinkService } from '@/common/link-service';
+import { ConversationsService } from '@/conversations/conversations.service';
 
 export function createMockEmailClient(): EmailClient {
   return {
@@ -23,5 +24,6 @@ export function useWorkspaceManagerFactory(
     linkService,
     new RoleService(),
     workspaceInviteService,
+    new ConversationsService(prismaService),
   );
 }

--- a/src/commands/commands.module.ts
+++ b/src/commands/commands.module.ts
@@ -4,9 +4,16 @@ import { PrismaModule } from '@/prisma/prisma.module';
 import { AuthModule } from '@/auth/auth.module';
 import { WorkspaceModule } from '@/workspace/workspace.module';
 import { FeatureFlagModule } from '@/feature-flag/feature-flag.module';
+import { ConversationsModule } from '@/conversations/conversations.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, WorkspaceModule, FeatureFlagModule],
+  imports: [
+    PrismaModule,
+    AuthModule,
+    WorkspaceModule,
+    FeatureFlagModule,
+    ConversationsModule,
+  ],
   providers: [SetupAdministrativeWorkspaceCommand],
   exports: [SetupAdministrativeWorkspaceCommand],
 })

--- a/src/commands/setup-administrative-workspace.command.spec.ts
+++ b/src/commands/setup-administrative-workspace.command.spec.ts
@@ -22,6 +22,7 @@ import { faker } from '@faker-js/faker';
 import { LinkService } from '@/common/link-service';
 import { WorkspaceManager } from '@/workspace/workspace-manager.service';
 import { RoleService } from '@/permission/role/role.service';
+import { ConversationsService } from '@/conversations/conversations.service';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
 import { AuthService } from '@/auth/auth.service';
 import PasswordGenerator from '@/auth/services/password.generator';
@@ -66,6 +67,7 @@ describe('SetupAdministrativeWorkspaceCommand', () => {
       jest.fn() as unknown as LinkService,
       new RoleService(),
       new WorkspaceInviteService(prismaService, authService),
+      new ConversationsService(prismaService),
     );
 
     command = new SetupAdministrativeWorkspaceCommand(

--- a/src/commands/setup-administrative-workspace.command.spec.ts
+++ b/src/commands/setup-administrative-workspace.command.spec.ts
@@ -52,6 +52,7 @@ describe('SetupAdministrativeWorkspaceCommand', () => {
     const teammateService = new TeammatesService(prismaService);
     const roleService = new RoleService();
     const permissionService = new PermissionService(prismaService, roleService);
+    const conversationsService = new ConversationsService(prismaService);
     const authService = new AuthService(
       mockSupabaseClient as unknown as SupabaseClient,
       new PasswordGenerator(),
@@ -75,6 +76,7 @@ describe('SetupAdministrativeWorkspaceCommand', () => {
       authService,
       workspaceManager,
       featureFlagManager,
+      conversationsService,
     );
   });
 

--- a/src/commands/setup-administrative-workspace.command.spec.ts
+++ b/src/commands/setup-administrative-workspace.command.spec.ts
@@ -68,7 +68,7 @@ describe('SetupAdministrativeWorkspaceCommand', () => {
       jest.fn() as unknown as LinkService,
       new RoleService(),
       new WorkspaceInviteService(prismaService, authService),
-      new ConversationsService(prismaService),
+      conversationsService,
     );
 
     command = new SetupAdministrativeWorkspaceCommand(

--- a/src/commands/setup-administrative-workspace.command.ts
+++ b/src/commands/setup-administrative-workspace.command.ts
@@ -7,6 +7,7 @@ import { CreateSuperAdminStep } from '@/workspace/steps/create-super-admin';
 import { CreateSelfConversationStep } from '@/workspace/steps/create-self-conversation';
 import { ENVOYE_WORKSPACE_CODE } from '@/feature-flag/const';
 import FeatureFlagManager from '@/feature-flag/manager';
+import { ConversationsService } from '@/conversations/conversations.service';
 
 interface Options {
   email: string;
@@ -27,7 +28,7 @@ export class SetupAdministrativeWorkspaceCommand extends CommandRunner {
     private readonly authService: AuthService,
     private readonly workspaceManager: WorkspaceManager,
     private readonly featureFlagManager: FeatureFlagManager,
-    private readonly conversationsService: any,
+    private readonly conversationsService: ConversationsService,
   ) {
     super();
   }
@@ -50,9 +51,9 @@ export class SetupAdministrativeWorkspaceCommand extends CommandRunner {
       [
         new CreateSuperAdminStep(this.prismaService),
         new CreateSelfConversationStep(
-                  this.conversationsService,
-                  this.prismaService,
-                )
+          this.conversationsService,
+          this.prismaService,
+        ),
       ],
     );
 

--- a/src/commands/setup-administrative-workspace.command.ts
+++ b/src/commands/setup-administrative-workspace.command.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { AuthService } from '@/auth/auth.service';
 import { WorkspaceManager } from '@/workspace/workspace-manager.service';
 import { CreateSuperAdminStep } from '@/workspace/steps/create-super-admin';
+import { CreateSelfConversationStep } from '@/workspace/steps/create-self-conversation';
 import { ENVOYE_WORKSPACE_CODE } from '@/feature-flag/const';
 import FeatureFlagManager from '@/feature-flag/manager';
 
@@ -26,6 +27,7 @@ export class SetupAdministrativeWorkspaceCommand extends CommandRunner {
     private readonly authService: AuthService,
     private readonly workspaceManager: WorkspaceManager,
     private readonly featureFlagManager: FeatureFlagManager,
+    private readonly conversationsService: any,
   ) {
     super();
   }
@@ -45,7 +47,13 @@ export class SetupAdministrativeWorkspaceCommand extends CommandRunner {
     await this.workspaceManager.runPostWorkspaceCreationSteps(
       workspaceDetails,
       preverification,
-      [new CreateSuperAdminStep(this.prismaService)],
+      [
+        new CreateSuperAdminStep(this.prismaService),
+        new CreateSelfConversationStep(
+                  this.conversationsService,
+                  this.prismaService,
+                )
+      ],
     );
 
     this.logger.log(`Successfully created ${workspaceDetails.name}`);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -54,3 +54,16 @@ export function sentenceCase(value: string): string {
   if (!trimmed) return trimmed;
   return trimmed[0].toUpperCase() + trimmed.slice(1).toLowerCase();
 }
+
+export function repeat(n: number, fn: () => void): void {
+  for (let i = 0; i < n; i++) {
+    fn();
+  }
+}
+
+export function repeatFn<T>(
+  n: number,
+  fn: () => Promise<T>,
+): (() => Promise<T>)[] {
+  return Array.from({ length: n }, () => fn);
+}

--- a/src/conversations/conversations.module.ts
+++ b/src/conversations/conversations.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ConversationsService } from './conversations.service';
+
+@Module({
+  providers: [ConversationsService],
+  exports: [ConversationsService],
+})
+export class ConversationsModule {}

--- a/src/conversations/conversations.service.spec.ts
+++ b/src/conversations/conversations.service.spec.ts
@@ -6,35 +6,29 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { createTestApp } from '@/test-helpers/test-app';
 import Factory, { PersistStrategy } from '@/factories/factory';
 import teammateFactory from '@/factories/teammate.factory';
-import { setupWorkspaceWithTeammate } from '@/test-helpers/workspace-helpers';
+import {
+  setupWorkspaceWithMultipleTeammates,
+  setupWorkspaceWithTeammate,
+} from '@/test-helpers/workspace-helpers';
 import { ConversationsService } from './conversations.service';
-import { ConversationStatus, Teammate, Workspace } from '@/generated/prisma/client';
+import { ConversationStatus } from '@/generated/prisma/client';
 
 describe('ConversationsService', () => {
   let service: ConversationsService;
   let app: INestApplication;
   let prismaService: PrismaService;
   let factory: PersistStrategy;
-  let workspace: Workspace;
-  let teammate: Teammate;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [ConfigModule.forRoot(), PrismaModule],
-      providers: [ConversationsService],
+      providers: [],
     }).compile();
     app = await createTestApp(module);
     prismaService = app.get<PrismaService>(PrismaService);
     service = new ConversationsService(prismaService);
 
     factory = Factory.createStrategy(prismaService);
-
-    const setup = await setupWorkspaceWithTeammate(
-      factory,
-      teammateFactory.build({ email: 'owner@useenvoye.com' }),
-    );
-    workspace = setup.workspace;
-    teammate = setup.teammate;
   });
 
   afterEach(async () => {
@@ -46,6 +40,10 @@ describe('ConversationsService', () => {
 
   describe('createSelfConversation', () => {
     it('creates an open conversation with the teammate as sole owner participant', async () => {
+      const { workspace, teammate } = await setupWorkspaceWithTeammate(
+        factory,
+        teammateFactory.build({ email: 'owner@useenvoye.com' }),
+      );
       const conversation = await service.createSelfConversation(
         workspace.code,
         teammate.id,
@@ -54,14 +52,39 @@ describe('ConversationsService', () => {
       expect(conversation.workspaceCode).toBe(workspace.code);
       expect(conversation.status).toBe(ConversationStatus.OPEN);
 
-      const participants =
-        await prismaService.conversationParticipant.findMany({
+      const participants = await prismaService.conversationParticipant.findMany(
+        {
           where: { conversationId: conversation.id },
-        });
+        },
+      );
       expect(participants).toHaveLength(1);
       expect(participants[0].teammateId).toBe(teammate.id);
       expect(participants[0].isOwner).toBe(true);
       expect(participants[0].workspaceCode).toBe(workspace.code);
+    });
+  });
+
+  describe('createConversation', () => {
+    it('creates a conversation with two participants', async () => {
+      const { workspace, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 4);
+
+      const [dan, marvin] = teammates.slice(2);
+      const conversation = await service.createConversation(
+        workspace.code,
+        marvin.id,
+        dan.email,
+      );
+
+      const participants = await prismaService.conversationParticipant.findMany(
+        {
+          where: { conversationId: conversation.id },
+        },
+      );
+
+      expect(participants).toHaveLength(2);
+      expect(participants[0].isOwner).toBe(true);
+      expect(participants[0].teammateId).toBe(dan.id);
     });
   });
 });

--- a/src/conversations/conversations.service.spec.ts
+++ b/src/conversations/conversations.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { INestApplication } from '@nestjs/common';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { PrismaService } from '@/prisma/prisma.service';
+import { createTestApp } from '@/test-helpers/test-app';
+import Factory, { PersistStrategy } from '@/factories/factory';
+import teammateFactory from '@/factories/teammate.factory';
+import { setupWorkspaceWithTeammate } from '@/test-helpers/workspace-helpers';
+import { ConversationsService } from './conversations.service';
+import { ConversationStatus, Teammate, Workspace } from '@/generated/prisma/client';
+
+describe('ConversationsService', () => {
+  let service: ConversationsService;
+  let app: INestApplication;
+  let prismaService: PrismaService;
+  let factory: PersistStrategy;
+  let workspace: Workspace;
+  let teammate: Teammate;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot(), PrismaModule],
+      providers: [ConversationsService],
+    }).compile();
+    app = await createTestApp(module);
+    service = app.get<ConversationsService>(ConversationsService);
+    prismaService = app.get<PrismaService>(PrismaService);
+    factory = Factory.createStrategy(prismaService);
+
+    const setup = await setupWorkspaceWithTeammate(
+      factory,
+      teammateFactory.build({ email: 'owner@useenvoye.com' }),
+    );
+    workspace = setup.workspace;
+    teammate = setup.teammate;
+  });
+
+  afterEach(async () => {
+    await prismaService.conversation.deleteMany();
+    await prismaService.teammate.deleteMany();
+    await prismaService.workspace.deleteMany();
+    await app.close();
+  });
+
+  describe('createSelfConversation', () => {
+    it('creates an open conversation with the teammate as sole owner participant', async () => {
+      const conversation = await service.createSelfConversation(
+        workspace.code,
+        teammate.id,
+      );
+
+      expect(conversation.workspaceCode).toBe(workspace.code);
+      expect(conversation.status).toBe(ConversationStatus.OPEN);
+
+      const participants =
+        await prismaService.conversationParticipant.findMany({
+          where: { conversationId: conversation.id },
+        });
+      expect(participants).toHaveLength(1);
+      expect(participants[0].teammateId).toBe(teammate.id);
+      expect(participants[0].isOwner).toBe(true);
+      expect(participants[0].workspaceCode).toBe(workspace.code);
+    });
+  });
+});

--- a/src/conversations/conversations.service.spec.ts
+++ b/src/conversations/conversations.service.spec.ts
@@ -24,8 +24,9 @@ describe('ConversationsService', () => {
       providers: [ConversationsService],
     }).compile();
     app = await createTestApp(module);
-    service = app.get<ConversationsService>(ConversationsService);
     prismaService = app.get<PrismaService>(PrismaService);
+    service = new ConversationsService(prismaService);
+
     factory = Factory.createStrategy(prismaService);
 
     const setup = await setupWorkspaceWithTeammate(

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/prisma/prisma.service';
+import { CreateConversationDto } from './dto/create-conversation.dto';
+import { Conversation } from '@/generated/prisma/client';
+
+@Injectable()
+export class ConversationsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createConversation(
+    dto: CreateConversationDto,
+    senderEmail: string,
+  ): Promise<Conversation> {
+    const sender = await this.prisma.teammate.findFirstOrThrow({
+      where: { workspaceCode: dto.workspaceCode, email: senderEmail },
+    });
+
+    return this.prisma.$transaction(async (tx) => {
+      const conversation = await tx.conversation.create({
+        data: {
+          workspaceCode: dto.workspaceCode,
+          customerInfo: dto.customerInfo,
+          subject: dto.subject,
+        },
+      });
+
+      await tx.conversationParticipant.createMany({
+        data: [
+          {
+            workspaceCode: dto.workspaceCode,
+            conversationId: conversation.id,
+            teammateId: sender.id,
+          },
+          {
+            workspaceCode: dto.workspaceCode,
+            conversationId: conversation.id,
+            teammateId: dto.recipientTeammateId,
+          },
+        ],
+      });
+
+      return conversation;
+    });
+  }
+}

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -41,4 +41,28 @@ export class ConversationsService {
       return conversation;
     });
   }
+
+  async createSelfConversation(
+    workspaceCode: string,
+    teammateId: number,
+  ): Promise<Conversation> {
+    return this.prisma.$transaction(async (tx) => {
+      const conversation = await tx.conversation.create({
+        data: {
+          workspaceCode,
+        },
+      });
+
+      await tx.conversationParticipant.create({
+        data: {
+          workspaceCode,
+          conversationId: conversation.id,
+          teammateId,
+          isOwner: true,
+        },
+      });
+
+      return conversation;
+    });
+  }
 }

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -18,9 +18,7 @@ export class ConversationsService {
     return this.prisma.$transaction(async (tx) => {
       const conversation = await tx.conversation.create({
         data: {
-          workspaceCode: dto.workspaceCode,
-          customerInfo: dto.customerInfo,
-          subject: dto.subject,
+          workspaceCode: dto.workspaceCode
         },
       });
 
@@ -30,12 +28,13 @@ export class ConversationsService {
             workspaceCode: dto.workspaceCode,
             conversationId: conversation.id,
             teammateId: sender.id,
+            isOwner: true
           },
           {
             workspaceCode: dto.workspaceCode,
             conversationId: conversation.id,
             teammateId: dto.recipientTeammateId,
-          },
+          }
         ],
       });
 

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { CreateConversationDto } from './dto/create-conversation.dto';
 import { Conversation } from '@/generated/prisma/client';
 
 @Injectable()
@@ -8,32 +7,33 @@ export class ConversationsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async createConversation(
-    dto: CreateConversationDto,
+    workspaceCode: string,
+    recipientTeammateId: number,
     senderEmail: string,
   ): Promise<Conversation> {
     const sender = await this.prisma.teammate.findFirstOrThrow({
-      where: { workspaceCode: dto.workspaceCode, email: senderEmail },
+      where: { workspaceCode: workspaceCode, email: senderEmail },
     });
 
     const conversation = await this.prisma.conversation.create({
       data: {
-        workspaceCode: dto.workspaceCode
+        workspaceCode: workspaceCode,
       },
     });
 
     await this.prisma.conversationParticipant.createMany({
       data: [
         {
-          workspaceCode: dto.workspaceCode,
+          workspaceCode: workspaceCode,
           conversationId: conversation.id,
           teammateId: sender.id,
-          isOwner: true
+          isOwner: true,
         },
         {
-          workspaceCode: dto.workspaceCode,
+          workspaceCode: workspaceCode,
           conversationId: conversation.id,
-          teammateId: dto.recipientTeammateId,
-        }
+          teammateId: recipientTeammateId,
+        },
       ],
     });
 

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -15,54 +15,50 @@ export class ConversationsService {
       where: { workspaceCode: dto.workspaceCode, email: senderEmail },
     });
 
-    return this.prisma.$transaction(async (tx) => {
-      const conversation = await tx.conversation.create({
-        data: {
-          workspaceCode: dto.workspaceCode
-        },
-      });
-
-      await tx.conversationParticipant.createMany({
-        data: [
-          {
-            workspaceCode: dto.workspaceCode,
-            conversationId: conversation.id,
-            teammateId: sender.id,
-            isOwner: true
-          },
-          {
-            workspaceCode: dto.workspaceCode,
-            conversationId: conversation.id,
-            teammateId: dto.recipientTeammateId,
-          }
-        ],
-      });
-
-      return conversation;
+    const conversation = await this.prisma.conversation.create({
+      data: {
+        workspaceCode: dto.workspaceCode
+      },
     });
+
+    await this.prisma.conversationParticipant.createMany({
+      data: [
+        {
+          workspaceCode: dto.workspaceCode,
+          conversationId: conversation.id,
+          teammateId: sender.id,
+          isOwner: true
+        },
+        {
+          workspaceCode: dto.workspaceCode,
+          conversationId: conversation.id,
+          teammateId: dto.recipientTeammateId,
+        }
+      ],
+    });
+
+    return conversation;
   }
 
   async createSelfConversation(
     workspaceCode: string,
     teammateId: number,
   ): Promise<Conversation> {
-    return this.prisma.$transaction(async (tx) => {
-      const conversation = await tx.conversation.create({
-        data: {
-          workspaceCode,
-        },
-      });
-
-      await tx.conversationParticipant.create({
-        data: {
-          workspaceCode,
-          conversationId: conversation.id,
-          teammateId,
-          isOwner: true,
-        },
-      });
-
-      return conversation;
+    const conversation = await this.prisma.conversation.create({
+      data: {
+        workspaceCode,
+      },
     });
+
+    await this.prisma.conversationParticipant.create({
+      data: {
+        workspaceCode,
+        conversationId: conversation.id,
+        teammateId,
+        isOwner: true,
+      },
+    });
+
+    return conversation;
   }
 }

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateConversationDto {
+  @ApiProperty({ description: 'Workspace code', example: '12er56' })
+  @IsString()
+  @IsNotEmpty()
+  workspaceCode: string;
+
+  @ApiProperty({ description: 'Customer info', example: 'john@acme.com' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  customerInfo: string;
+
+  @ApiProperty({ description: 'Subject', example: 'Billing issue', required: false })
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  subject?: string;
+
+  @ApiProperty({ description: 'Teammate ID of the recipient', example: 5 })
+  @IsInt()
+  @IsNotEmpty()
+  recipientTeammateId: number;
+}

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateConversationDto {
   @ApiProperty({ description: 'Workspace code', example: '12er56' })

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -7,18 +7,6 @@ export class CreateConversationDto {
   @IsNotEmpty()
   workspaceCode: string;
 
-  @ApiProperty({ description: 'Customer info', example: 'john@acme.com' })
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(100)
-  customerInfo: string;
-
-  @ApiProperty({ description: 'Subject', example: 'Billing issue', required: false })
-  @IsString()
-  @IsOptional()
-  @MaxLength(100)
-  subject?: string;
-
   @ApiProperty({ description: 'Teammate ID of the recipient', example: 5 })
   @IsInt()
   @IsNotEmpty()

--- a/src/test-helpers/workspace-helpers.ts
+++ b/src/test-helpers/workspace-helpers.ts
@@ -8,6 +8,7 @@ import FeatureFlagManager from '@/feature-flag/manager';
 import featureFlagFactory from '@/factories/feature-flag.factory';
 import { ENVOYE_WORKSPACE_CODE } from '@/feature-flag/const';
 import { ROLES } from '@/permission/types';
+import { repeatFn } from '@/common/utils';
 
 export async function setupSuperAdmin(
   factory: PersistStrategy,
@@ -51,6 +52,33 @@ export async function setupWorkspaceWithTeammate(
   );
   const createdTeammate = await factory.persist('teammate', () => teammate);
   return { workspace: workspace, teammate: createdTeammate };
+}
+
+async function addTeammateToWorkspace(
+  factory: PersistStrategy,
+  workspaceCode: string,
+) {
+  return await factory.persist('teammate', () =>
+    teammateFactory.build({ workspaceCode: workspaceCode }),
+  );
+}
+
+export async function setupWorkspaceWithMultipleTeammates(
+  factory: PersistStrategy,
+  numberOfTeammates: number,
+) {
+  const workspace = await factory.persist('workspace', () =>
+    workspaceFactory.build(),
+  );
+
+  const tasks = repeatFn(
+    numberOfTeammates,
+    async () => await addTeammateToWorkspace(factory, workspace.code),
+  );
+
+  const teammates = await Promise.all(tasks.map((task) => task()));
+
+  return { workspace, teammates };
 }
 
 export async function setupWorkspaceWithFeatures(

--- a/src/workspace/steps/create-self-conversation.spec.ts
+++ b/src/workspace/steps/create-self-conversation.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { INestApplication } from '@nestjs/common';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { PrismaService } from '@/prisma/prisma.service';
+import { createTestApp } from '@/test-helpers/test-app';
+import { CreateSelfConversationStep } from '@/workspace/steps/create-self-conversation';
+import { ConversationsService } from '@/conversations/conversations.service';
+import { WorkspaceDetails } from '@/workspace/domain/workspace-details';
+import { PointOfContact } from '@/workspace/domain/point-of-contact';
+import preVerificationFactory from '@/factories/roadmap/preverification.factory';
+import { CompanyProfile, PreVerification, Workspace } from '@/generated/prisma/client';
+
+describe('CreateSelfConversationStep', () => {
+  let step: CreateSelfConversationStep;
+  let app: INestApplication;
+  let prismaService: PrismaService;
+  let conversationsService: ConversationsService;
+
+  async function miniWorkspaceWithAdmin(
+    details: PreVerification,
+  ): Promise<WorkspaceDetails> {
+    const companyProfile: CompanyProfile =
+      await prismaService.companyProfile.create({
+        data: {
+          companyName: details.companyName,
+          pointOfContactEmail: details.email,
+          phoneCountryCode: details.phoneCountryCode,
+          phoneNumber: details.phoneNumber,
+        },
+      });
+    const workspace: Workspace = await prismaService.workspace.create({
+      data: {
+        name: companyProfile.companyName,
+        ownedById: companyProfile.id,
+        code: 'a3b9c2',
+      },
+    });
+    await prismaService.teammate.create({
+      data: {
+        email: details.email,
+        firstName: details.firstName,
+        lastName: details.lastName,
+        username: `${details.firstName.toLowerCase()}.${details.lastName.toLowerCase()}`,
+        workspaceCode: workspace.code,
+      },
+    });
+    return WorkspaceDetails.from(workspace, PointOfContact.from(details));
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot(), PrismaModule],
+      providers: [ConversationsService],
+    }).compile();
+    app = await createTestApp(module);
+    prismaService = app.get<PrismaService>(PrismaService);
+    conversationsService = app.get<ConversationsService>(ConversationsService);
+    step = new CreateSelfConversationStep(conversationsService, prismaService);
+  });
+
+  afterEach(async () => {
+    await prismaService.conversation.deleteMany();
+    await prismaService.teammate.deleteMany();
+    await prismaService.workspace.deleteMany();
+    await prismaService.companyProfile.deleteMany();
+    await app.close();
+  });
+
+  it('creates a self-conversation for the admin and rolls it back', async () => {
+    const workspaceDetails = await miniWorkspaceWithAdmin(
+      preVerificationFactory.build(),
+    );
+
+    await step.execute(workspaceDetails);
+
+    const admin = await prismaService.teammate.findFirstOrThrow({
+      where: {
+        workspaceCode: workspaceDetails.code,
+        email: workspaceDetails.pointOfContact.email,
+      },
+    });
+    const participants = await prismaService.conversationParticipant.findMany({
+      where: { workspaceCode: workspaceDetails.code, teammateId: admin.id },
+    });
+    expect(participants).toHaveLength(1);
+    expect(participants[0].isOwner).toBe(true);
+
+    await step.compensate(workspaceDetails);
+
+    expect(
+      await prismaService.conversation.count({
+        where: { workspaceCode: workspaceDetails.code },
+      }),
+    ).toBe(0);
+  });
+
+  it('compensate is a no-op when execute did not run', async () => {
+    const workspaceDetails = await miniWorkspaceWithAdmin(
+      preVerificationFactory.build(),
+    );
+    await expect(step.compensate(workspaceDetails)).resolves.not.toThrow();
+  });
+});

--- a/src/workspace/steps/create-self-conversation.spec.ts
+++ b/src/workspace/steps/create-self-conversation.spec.ts
@@ -8,44 +8,27 @@ import { CreateSelfConversationStep } from '@/workspace/steps/create-self-conver
 import { ConversationsService } from '@/conversations/conversations.service';
 import { WorkspaceDetails } from '@/workspace/domain/workspace-details';
 import { PointOfContact } from '@/workspace/domain/point-of-contact';
-import preVerificationFactory from '@/factories/roadmap/preverification.factory';
-import { CompanyProfile, PreVerification, Workspace } from '@/generated/prisma/client';
+import { setupWorkspaceWithMultipleTeammates } from '@/test-helpers/workspace-helpers';
+import { resetDb } from '@/test-helpers/rest-db';
+import Factory, { PersistStrategy } from '@/factories/factory';
 
 describe('CreateSelfConversationStep', () => {
   let step: CreateSelfConversationStep;
   let app: INestApplication;
   let prismaService: PrismaService;
   let conversationsService: ConversationsService;
+  let factory: PersistStrategy;
 
-  async function miniWorkspaceWithAdmin(
-    details: PreVerification,
-  ): Promise<WorkspaceDetails> {
-    const companyProfile: CompanyProfile =
-      await prismaService.companyProfile.create({
-        data: {
-          companyName: details.companyName,
-          pointOfContactEmail: details.email,
-          phoneCountryCode: details.phoneCountryCode,
-          phoneNumber: details.phoneNumber,
-        },
-      });
-    const workspace: Workspace = await prismaService.workspace.create({
-      data: {
-        name: companyProfile.companyName,
-        ownedById: companyProfile.id,
-        code: 'a3b9c2',
-      },
-    });
-    await prismaService.teammate.create({
-      data: {
-        email: details.email,
-        firstName: details.firstName,
-        lastName: details.lastName,
-        username: `${details.firstName.toLowerCase()}.${details.lastName.toLowerCase()}`,
-        workspaceCode: workspace.code,
-      },
-    });
-    return WorkspaceDetails.from(workspace, PointOfContact.from(details));
+  async function miniWorkspaceWithAdmin(): Promise<WorkspaceDetails> {
+    const { workspace, teammates } = await setupWorkspaceWithMultipleTeammates(
+      factory,
+      1,
+    );
+    const [owner] = teammates;
+    return WorkspaceDetails.from(
+      workspace,
+      new PointOfContact(owner.firstName, owner.lastName, owner.email),
+    );
   }
 
   beforeEach(async () => {
@@ -55,22 +38,18 @@ describe('CreateSelfConversationStep', () => {
     }).compile();
     app = await createTestApp(module);
     prismaService = app.get<PrismaService>(PrismaService);
+    factory = Factory.createStrategy(prismaService);
     conversationsService = app.get<ConversationsService>(ConversationsService);
     step = new CreateSelfConversationStep(conversationsService, prismaService);
   });
 
   afterEach(async () => {
-    await prismaService.conversation.deleteMany();
-    await prismaService.teammate.deleteMany();
-    await prismaService.workspace.deleteMany();
-    await prismaService.companyProfile.deleteMany();
+    await resetDb(prismaService);
     await app.close();
   });
 
   it('creates a self-conversation for the admin and rolls it back', async () => {
-    const workspaceDetails = await miniWorkspaceWithAdmin(
-      preVerificationFactory.build(),
-    );
+    const workspaceDetails = await miniWorkspaceWithAdmin();
 
     await step.execute(workspaceDetails);
 
@@ -96,9 +75,33 @@ describe('CreateSelfConversationStep', () => {
   });
 
   it('compensate is a no-op when execute did not run', async () => {
-    const workspaceDetails = await miniWorkspaceWithAdmin(
-      preVerificationFactory.build(),
-    );
+    const workspaceDetails = await miniWorkspaceWithAdmin();
     await expect(step.compensate(workspaceDetails)).resolves.not.toThrow();
+  });
+
+  it('only removes conversation for current workspace', async () => {
+    const { workspace, teammates } = await setupWorkspaceWithMultipleTeammates(
+      factory,
+      2,
+    );
+    const [laura, tumise] = teammates;
+    await conversationsService.createConversation(
+      workspace.code,
+      tumise.id,
+      laura.email,
+    );
+
+    const workspaceDetails = await miniWorkspaceWithAdmin();
+
+    await step.execute(workspaceDetails);
+    await step.compensate(workspaceDetails);
+
+    expect(
+      await prismaService.conversation.count({
+        where: { workspaceCode: workspaceDetails.code },
+      }),
+    ).toBe(0);
+
+    expect(await prismaService.conversation.count()).toBe(1);
   });
 });

--- a/src/workspace/steps/create-self-conversation.ts
+++ b/src/workspace/steps/create-self-conversation.ts
@@ -6,7 +6,6 @@ import { ConversationsService } from '@/conversations/conversations.service';
 
 export class CreateSelfConversationStep implements PostSetupStep {
   logger = new Logger(CreateSelfConversationStep.name);
-  private createdConversationId?: number;
 
   constructor(
     private readonly conversationsService: ConversationsService,
@@ -25,7 +24,6 @@ export class CreateSelfConversationStep implements PostSetupStep {
       workspaceDetails.code,
       admin.id,
     );
-    this.createdConversationId = conversation.id;
 
     this.logger.log(
       `Successfully created self-conversation for admin; workspaceCode=${workspaceDetails.code} conversationId=${conversation.id}`,
@@ -33,14 +31,11 @@ export class CreateSelfConversationStep implements PostSetupStep {
   }
 
   async compensate(workspaceDetails: WorkspaceDetails): Promise<void> {
-    if (this.createdConversationId === undefined) {
-      return;
-    }
     this.logger.warn(
-      `Removing self-conversation as compensating action; workspaceCode=${workspaceDetails.code} conversationId=${this.createdConversationId}`,
+      `Removing self-conversation as compensating action; workspaceCode=${workspaceDetails.code}`,
     );
-    await this.prismaService.conversation.delete({
-      where: { id: this.createdConversationId },
+    await this.prismaService.conversation.deleteMany({
+      where: { workspaceCode: workspaceDetails.code },
     });
   }
 }

--- a/src/workspace/steps/create-self-conversation.ts
+++ b/src/workspace/steps/create-self-conversation.ts
@@ -31,11 +31,12 @@ export class CreateSelfConversationStep implements PostSetupStep {
   }
 
   async compensate(workspaceDetails: WorkspaceDetails): Promise<void> {
-    this.logger.warn(
-      `Removing self-conversation as compensating action; workspaceCode=${workspaceDetails.code}`,
-    );
     await this.prismaService.conversation.deleteMany({
       where: { workspaceCode: workspaceDetails.code },
     });
+
+    this.logger.warn(
+      `Removing self-conversation as compensating action; workspaceCode=${workspaceDetails.code}`,
+    );
   }
 }

--- a/src/workspace/steps/create-self-conversation.ts
+++ b/src/workspace/steps/create-self-conversation.ts
@@ -1,0 +1,46 @@
+import { Logger } from '@nestjs/common';
+import { PrismaService } from '@/prisma/prisma.service';
+import { WorkspaceDetails } from '@/workspace/domain/workspace-details';
+import { PostSetupStep } from '@/workspace/steps/postsetup-step';
+import { ConversationsService } from '@/conversations/conversations.service';
+
+export class CreateSelfConversationStep implements PostSetupStep {
+  logger = new Logger(CreateSelfConversationStep.name);
+  private createdConversationId?: number;
+
+  constructor(
+    private readonly conversationsService: ConversationsService,
+    private readonly prismaService: PrismaService,
+  ) {}
+
+  async execute(workspaceDetails: WorkspaceDetails): Promise<void> {
+    const admin = await this.prismaService.teammate.findFirstOrThrow({
+      where: {
+        workspaceCode: workspaceDetails.code,
+        email: workspaceDetails.pointOfContact.email,
+      },
+    });
+
+    const conversation = await this.conversationsService.createSelfConversation(
+      workspaceDetails.code,
+      admin.id,
+    );
+    this.createdConversationId = conversation.id;
+
+    this.logger.log(
+      `Successfully created self-conversation for admin; workspaceCode=${workspaceDetails.code} conversationId=${conversation.id}`,
+    );
+  }
+
+  async compensate(workspaceDetails: WorkspaceDetails): Promise<void> {
+    if (this.createdConversationId === undefined) {
+      return;
+    }
+    this.logger.warn(
+      `Removing self-conversation as compensating action; workspaceCode=${workspaceDetails.code} conversationId=${this.createdConversationId}`,
+    );
+    await this.prismaService.conversation.delete({
+      where: { id: this.createdConversationId },
+    });
+  }
+}

--- a/src/workspace/workspace-invite-service.spec.ts
+++ b/src/workspace/workspace-invite-service.spec.ts
@@ -23,6 +23,7 @@ import { AuthService } from '@/auth/auth.service';
 import { Teammate, Workspace } from '@/generated/prisma/client';
 import { mockAuthService } from '@/test-helpers/mocks';
 import { LinkService } from '@/common/link-service';
+import { ConversationsService } from '@/conversations/conversations.service';
 
 describe('WorkspaceInviteService', () => {
   let app: INestApplication;
@@ -56,6 +57,7 @@ describe('WorkspaceInviteService', () => {
         RoleService,
         WorkspaceInviteService,
         LinkService,
+        ConversationsService,
         {
           provide: AuthService,
           useValue: mockAuthService as unknown as AuthService,

--- a/src/workspace/workspace-manager.service.spec.ts
+++ b/src/workspace/workspace-manager.service.spec.ts
@@ -63,8 +63,7 @@ describe('WorkspaceService', () => {
     workspaceInviteService = app.get<WorkspaceInviteService>(
       WorkspaceInviteService,
     );
-    conversationsService =
-      app.get<ConversationsService>(ConversationsService);
+    conversationsService = app.get<ConversationsService>(ConversationsService);
     factory = Factory.createStrategy(prismaService);
     preVerificationDetails = await factory.persist('preverification', () =>
       preVerificationFactory.build(),

--- a/src/workspace/workspace-manager.service.spec.ts
+++ b/src/workspace/workspace-manager.service.spec.ts
@@ -29,6 +29,7 @@ import { LinkService } from '@/common/link-service';
 import { AuthService } from '@/auth/auth.service';
 import { mockAuthService } from '@/test-helpers/mocks';
 import CompanyProfileFactory from '@/factories/company-profile.factory';
+import { ConversationsService } from '@/conversations/conversations.service';
 
 describe('WorkspaceService', () => {
   let service: WorkspaceManager;
@@ -38,6 +39,7 @@ describe('WorkspaceService', () => {
   let factory: PersistStrategy;
   let preVerificationDetails: PreVerification;
   let workspaceInviteService: WorkspaceInviteService;
+  let conversationsService: ConversationsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -47,6 +49,7 @@ describe('WorkspaceService', () => {
         LinkService,
         RoleService,
         WorkspaceInviteService,
+        ConversationsService,
         {
           provide: AuthService,
           useValue: mockAuthService as unknown as AuthService,
@@ -60,6 +63,8 @@ describe('WorkspaceService', () => {
     workspaceInviteService = app.get<WorkspaceInviteService>(
       WorkspaceInviteService,
     );
+    conversationsService =
+      app.get<ConversationsService>(ConversationsService);
     factory = Factory.createStrategy(prismaService);
     preVerificationDetails = await factory.persist('preverification', () =>
       preVerificationFactory.build(),
@@ -67,6 +72,7 @@ describe('WorkspaceService', () => {
   });
 
   afterEach(async () => {
+    await prismaService.conversation.deleteMany();
     await prismaService.preVerification.deleteMany();
     await prismaService.companyProfile.deleteMany();
     await prismaService.workspace.deleteMany();
@@ -248,6 +254,40 @@ describe('WorkspaceService', () => {
       it('does not run teammate create step successfully', async () => {
         jest
           .spyOn(prismaService.teammate, 'create')
+          .mockRejectedValue(new Error('Database error'));
+
+        await expect(
+          service.setup(
+            preVerificationDetails.email,
+            preVerificationDetails.id,
+          ),
+        ).rejects.toThrow('Database error');
+
+        await assertRollbackHappened(preVerificationDetails);
+      });
+    });
+
+    describe('SelfConversation', () => {
+      it('creates a self-conversation for the new admin', async () => {
+        await service.setup(
+          preVerificationDetails.email,
+          preVerificationDetails.id,
+        );
+
+        const admin = await prismaService.teammate.findFirstOrThrow({
+          where: { email: preVerificationDetails.email },
+        });
+        const participants =
+          await prismaService.conversationParticipant.findMany({
+            where: { teammateId: admin.id },
+          });
+        expect(participants).toHaveLength(1);
+        expect(participants[0].isOwner).toBe(true);
+      });
+
+      it('rolls everything back when self-conversation creation fails', async () => {
+        jest
+          .spyOn(conversationsService, 'createSelfConversation')
           .mockRejectedValue(new Error('Database error'));
 
         await expect(

--- a/src/workspace/workspace-manager.service.spec.ts
+++ b/src/workspace/workspace-manager.service.spec.ts
@@ -298,6 +298,27 @@ describe('WorkspaceService', () => {
         ).rejects.toThrow('Database error');
 
         await assertRollbackHappened(preVerificationDetails);
+        expect(await prismaService.conversation.count()).toBe(0);
+      });
+
+      it('keeps the conversation from a successful setup when a later setup fails', async () => {
+        await service.setup(
+          preVerificationDetails.email,
+          preVerificationDetails.id,
+        );
+
+        const failingDetails = await factory.persist('preverification', () =>
+          preVerificationFactory.build(),
+        );
+        jest
+          .spyOn(conversationsService, 'createSelfConversation')
+          .mockRejectedValue(new Error('Database error'));
+
+        await expect(
+          service.setup(failingDetails.email, failingDetails.id),
+        ).rejects.toThrow('Database error');
+
+        expect(await prismaService.conversation.count()).toBe(1);
       });
     });
   });

--- a/src/workspace/workspace-manager.service.ts
+++ b/src/workspace/workspace-manager.service.ts
@@ -29,6 +29,8 @@ import { RoleService } from '@/permission/role/role.service';
 import { ConcurrentLimit } from '@/common/concurrent-runner';
 import { WorkspaceInviteService } from '@/workspace/workspace-invite-service';
 import { LinkService } from '@/common/link-service';
+import { CreateSelfConversationStep } from '@/workspace/steps/create-self-conversation';
+import { ConversationsService } from '@/conversations/conversations.service';
 
 @Injectable()
 export class WorkspaceManager {
@@ -42,6 +44,7 @@ export class WorkspaceManager {
     private readonly linkService: LinkService,
     private readonly roleService: RoleService,
     private readonly workspaceInviteService: WorkspaceInviteService,
+    private readonly conversationsService: ConversationsService,
   ) {}
 
   async runPostWorkspaceCreationSteps(
@@ -93,7 +96,13 @@ export class WorkspaceManager {
     await this.runPostWorkspaceCreationSteps(
       workspaceDetails,
       preverificationDetails,
-      [new CreateWorkspaceAdminStep(this.prismaService)],
+      [
+        new CreateWorkspaceAdminStep(this.prismaService),
+        new CreateSelfConversationStep(
+          this.conversationsService,
+          this.prismaService,
+        ),
+      ],
     );
 
     return workspaceDetails;

--- a/src/workspace/workspace.controller.spec.ts
+++ b/src/workspace/workspace.controller.spec.ts
@@ -36,6 +36,7 @@ import { mockAuthService } from '@/test-helpers/mocks';
 import { LinkService } from '@/common/link-service';
 import DebounceService, { DEBOUNCE_SERVICE } from '@/common/debounce.service';
 import { Time } from '@/common/utils';
+import { ConversationsService } from '@/conversations/conversations.service';
 
 describe('WorkspaceController', () => {
   let requestUser: RequestUser;
@@ -56,6 +57,7 @@ describe('WorkspaceController', () => {
         RoleService,
         PermissionService,
         WorkspaceInviteService,
+        ConversationsService,
         {
           provide: DEBOUNCE_SERVICE,
           useClass: DebounceService,

--- a/src/workspace/workspace.module.ts
+++ b/src/workspace/workspace.module.ts
@@ -8,9 +8,16 @@ import { MessagingModule } from '@/messaging/messaging.module';
 import { LinkService } from '@/common/link-service';
 import { AuthModule } from '@/auth/auth.module';
 import { DebounceServiceProvider } from '@/common/debounce.service';
+import { ConversationsModule } from '@/conversations/conversations.module';
 
 @Module({
-  imports: [PermissionModule, PrismaModule, MessagingModule, AuthModule],
+  imports: [
+    PermissionModule,
+    PrismaModule,
+    MessagingModule,
+    AuthModule,
+    ConversationsModule,
+  ],
   providers: [
     WorkspaceManager,
     LinkService,


### PR DESCRIPTION
When a workspace is first created,  we want a self conversation to be created during the process.

Followed the approach of keeping the conversation service action to the conversation service and importing the service into the workspace module. This will promote separation of concerns.