### PR TITLE
Add Sent at when creating send message payload

### DIFF
--- a/src/conversations/conversations.controller.spec.ts
+++ b/src/conversations/conversations.controller.spec.ts
@@ -8,6 +8,8 @@ import {
   INestApplication,
   NotFoundException,
 } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { PrismaService } from '@/prisma/prisma.service';
 import Factory, { PersistStrategy } from '@/factories/factory';
@@ -22,6 +24,11 @@ import teammateFactory from '@/factories/teammate.factory';
 import workspaceFactory from '@/factories/workspace.factory';
 import { resetDb } from '@/test-helpers/rest-db';
 import { ROLES } from '@/permission/types';
+import { CreateConversationDto } from '@/conversations/dto/create-conversation.dto';
+import { SendTextMessageDto } from '@/conversations/dto/send-message.dto';
+
+const validSentAt = new Date('2026-06-20T10:00:00.000Z');
+const futureSentAt = new Date(Date.now() + 60_000);
 
 describe('ConversationsController', () => {
   let requestUser: RequestUser;
@@ -80,6 +87,7 @@ describe('ConversationsController', () => {
         workspaceCode: koboMart.code,
         recipientTeammateId: marvin.id,
         openingMessage: ['Hey, how are you feeling.'],
+        sentAt: validSentAt,
       });
 
       expect(body.workspaceCode).toBe(koboMart.code);
@@ -110,6 +118,7 @@ describe('ConversationsController', () => {
         workspaceCode: koboMart.code,
         recipientTeammateId: dan.id,
         openingMessage: ['in the office today?'],
+        sentAt: validSentAt,
       });
 
       expect(body.workspaceCode).toBe(koboMart.code);
@@ -147,6 +156,7 @@ describe('ConversationsController', () => {
           workspaceCode: koboMart.code,
           recipientTeammateId: marvinInZuriBakery.id,
           openingMessage: ['wagwan G!'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(BadRequestException);
     });
@@ -170,6 +180,7 @@ describe('ConversationsController', () => {
           workspaceCode: '345dv5',
           recipientTeammateId: marvin.id,
           openingMessage: ['Welcome to Envoye!'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(ForbiddenException);
     });
@@ -188,6 +199,7 @@ describe('ConversationsController', () => {
           workspaceCode: koboMart.code,
           recipientTeammateId: marvin.id,
           openingMessage: ['Lets sync a bit later'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(ForbiddenException);
     });
@@ -208,8 +220,36 @@ describe('ConversationsController', () => {
           workspaceCode: koboMart.code,
           recipientTeammateId: 999999,
           openingMessage: ['Note to self'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('persists opening message with client-provided sentAt', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+      await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [ROLES.WorkspaceMember.code],
+        },
+      });
+      const marvin = teammates[1];
+
+      const body = await controller.createDirectMessage(requestUser, {
+        workspaceCode: koboMart.code,
+        recipientTeammateId: marvin.id,
+        openingMessage: ['Hey there'],
+        sentAt: validSentAt,
+      });
+
+      const openingMessage = await prismaService.message.findFirst({
+        where: { conversationId: body.id },
+      });
+
+      expect(openingMessage?.content).toBe('Hey there');
+      expect(openingMessage?.sentAt.toISOString()).toBe(validSentAt.toISOString());
     });
   });
 
@@ -231,6 +271,7 @@ describe('ConversationsController', () => {
         marvin.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       const conversations = await controller.listConversations(requestUser, {
@@ -262,6 +303,7 @@ describe('ConversationsController', () => {
         dan.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       const conversations = await controller.listConversations(requestUser, {
@@ -293,6 +335,7 @@ describe('ConversationsController', () => {
         marvin.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       const zuriBakery = await factory.persist('workspace', () =>
@@ -314,6 +357,7 @@ describe('ConversationsController', () => {
         marvinInZuriBakery.id,
         zuriBakery.code,
         [],
+        new Date(),
       );
 
       const koboMartConversations = await controller.listConversations(
@@ -404,12 +448,14 @@ describe('ConversationsController', () => {
         marvin.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       await controller.sendTextMessage(requestUser, {
         workspaceCode: koboMart.code,
         conversationId: conversation.id,
         message: ['Hey buddy'],
+        sentAt: validSentAt,
       });
 
       const createdMessage = await prismaService.message.findFirst({
@@ -422,6 +468,7 @@ describe('ConversationsController', () => {
 
       expect(createdMessage).toBeTruthy();
       expect(createdMessage?.content).toBe('Hey buddy');
+      expect(createdMessage?.sentAt.toISOString()).toBe(validSentAt.toISOString());
     });
 
     it('throws ForbiddenException when sender is not a participant', async () => {
@@ -444,6 +491,7 @@ describe('ConversationsController', () => {
         marvin.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       await expect(
@@ -451,6 +499,7 @@ describe('ConversationsController', () => {
           workspaceCode: koboMart.code,
           conversationId: conversation.id,
           message: ['Hey buddy'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(ForbiddenException);
     });
@@ -473,6 +522,7 @@ describe('ConversationsController', () => {
         marvin.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       await expect(
@@ -480,6 +530,7 @@ describe('ConversationsController', () => {
           workspaceCode: '345dv5',
           conversationId: conversation.id,
           message: ['Hey buddy'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(ForbiddenException);
     });
@@ -502,6 +553,7 @@ describe('ConversationsController', () => {
         marvin.id,
         koboMart.code,
         [],
+        new Date(),
       );
 
       await expect(
@@ -509,6 +561,7 @@ describe('ConversationsController', () => {
           workspaceCode: koboMart.code,
           conversationId: conversation.id,
           message: ['Hey buddy'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(ForbiddenException);
     });
@@ -530,8 +583,61 @@ describe('ConversationsController', () => {
           workspaceCode: koboMart.code,
           conversationId: 999999,
           message: ['Hey buddy'],
+          sentAt: validSentAt,
         }),
       ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('sentAt validation', () => {
+    it('rejects SendTextMessageDto when sentAt is omitted', async () => {
+      const dto = plainToInstance(SendTextMessageDto, {
+        workspaceCode: '12er56',
+        conversationId: 1,
+        message: ['Hey buddy'],
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.map((error) => error.property)).toContain('sentAt');
+    });
+
+    it('rejects SendTextMessageDto when sentAt is in the future', async () => {
+      const dto = plainToInstance(SendTextMessageDto, {
+        workspaceCode: '12er56',
+        conversationId: 1,
+        message: ['Hey buddy'],
+        sentAt: futureSentAt.toISOString(),
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.map((error) => error.property)).toContain('sentAt');
+    });
+
+    it('rejects CreateConversationDto when sentAt is omitted', async () => {
+      const dto = plainToInstance(CreateConversationDto, {
+        workspaceCode: '12er56',
+        recipientTeammateId: 1,
+        openingMessage: ['Hey buddy'],
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.map((error) => error.property)).toContain('sentAt');
+    });
+
+    it('rejects CreateConversationDto when sentAt is in the future', async () => {
+      const dto = plainToInstance(CreateConversationDto, {
+        workspaceCode: '12er56',
+        recipientTeammateId: 1,
+        openingMessage: ['Hey buddy'],
+        sentAt: futureSentAt.toISOString(),
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.map((error) => error.property)).toContain('sentAt');
     });
   });
 });

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -120,6 +120,7 @@ export class ConversationsController {
                   teammateIds[0],
                   workspaceCode,
                   dto.openingMessage,
+                  dto.sentAt,
                 );
               },
             );
@@ -174,6 +175,7 @@ export class ConversationsController {
                 dto.conversationId,
                 senderTeammate.id,
                 dto.message,
+                dto.sentAt,
               ),
           );
         } catch (error) {

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -1,10 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   ArrayNotEmpty,
   IsArray,
+  IsDate,
   IsInt,
   IsNotEmpty,
   IsString,
+  MaxDate,
 } from 'class-validator';
 import MaxCharacterLimit from '@/common/validators/max-character-limit';
 import { MAX_ENVOYE_MESSAGE_CHARACTERS } from '@/conversations/const';
@@ -33,4 +36,15 @@ export class CreateConversationDto {
   @IsNotEmpty({ each: true })
   @MaxCharacterLimit(MAX_ENVOYE_MESSAGE_CHARACTERS)
   openingMessage: string[];
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    example: '2026-06-24T12:00:00.000Z',
+  })
+  @Type(() => Date)
+  @IsDate()
+  @IsNotEmpty()
+  @MaxDate(() => new Date(), { message: 'sentAt cannot be in the future' })
+  sentAt: Date;
 }

--- a/src/conversations/dto/send-message.dto.ts
+++ b/src/conversations/dto/send-message.dto.ts
@@ -1,10 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   ArrayNotEmpty,
   IsArray,
+  IsDate,
   IsInt,
   IsNotEmpty,
   IsString,
+  MaxDate,
 } from 'class-validator';
 import MaxCharacterLimit from '@/common/validators/max-character-limit';
 import { MAX_ENVOYE_MESSAGE_CHARACTERS } from '@/conversations/const';
@@ -33,4 +36,15 @@ export class SendTextMessageDto {
   @IsNotEmpty({ each: true })
   @MaxCharacterLimit(MAX_ENVOYE_MESSAGE_CHARACTERS)
   message: string[];
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    example: '2026-06-24T12:00:00.000Z',
+  })
+  @Type(() => Date)
+  @IsDate()
+  @IsNotEmpty()
+  @MaxDate(() => new Date(), { message: 'sentAt cannot be in the future' })
+  sentAt: Date;
 }

--- a/src/conversations/messangers/envoye.spec.ts
+++ b/src/conversations/messangers/envoye.spec.ts
@@ -48,6 +48,7 @@ describe('EnvoyeMessenger', () => {
         teammate.id,
         workspace.code,
         [],
+        new Date(),
       );
 
       expect(conversation.workspaceCode).toBe(workspace.code);
@@ -74,6 +75,7 @@ describe('EnvoyeMessenger', () => {
         marvin.id,
         workspace.code,
         [],
+        new Date(),
       );
 
       const participants = await prismaService.conversationParticipant.findMany(
@@ -85,6 +87,32 @@ describe('EnvoyeMessenger', () => {
       expect(participants).toHaveLength(2);
       expect(participants[0].isOwner).toBe(true);
       expect(participants[0].teammateId).toBe(dan.id);
+    });
+  });
+
+  describe('sendTextMessage', () => {
+    it('persists client-provided sentAt', async () => {
+      const { workspace, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+      const [dan, marvin] = teammates;
+      const sentAt = new Date('2026-06-20T10:00:00.000Z');
+
+      const conversation = await messenger.sendOpeningTextMessage(
+        dan.id,
+        marvin.id,
+        workspace.code,
+        [],
+        new Date(),
+      );
+
+      const message = await messenger.sendTextMessage(
+        conversation.id,
+        dan.id,
+        ['Hello'],
+        sentAt,
+      );
+
+      expect(message.sentAt.toISOString()).toBe(sentAt.toISOString());
     });
   });
 });

--- a/src/conversations/messangers/envoye.ts
+++ b/src/conversations/messangers/envoye.ts
@@ -13,6 +13,7 @@ export default class EnvoyeMessenger implements Messenger {
     recipientTeammateId: number,
     workspaceCode: string,
     openingMessage: string[],
+    sentAt: Date,
   ): Promise<Conversation> {
     const conversation = await this.prisma.conversation.create({
       data: {
@@ -52,6 +53,7 @@ export default class EnvoyeMessenger implements Messenger {
         conversation,
         senderId,
         openingMessage,
+        sentAt,
       );
     }
 
@@ -62,6 +64,7 @@ export default class EnvoyeMessenger implements Messenger {
     conversationId: number,
     senderId: number,
     content: string[],
+    sentAt: Date,
   ): Promise<Message> {
     const conversation = await this.prisma.conversation.findUniqueOrThrow({
       where: {
@@ -72,6 +75,7 @@ export default class EnvoyeMessenger implements Messenger {
       conversation,
       senderId,
       content,
+      sentAt,
     );
   }
 
@@ -79,6 +83,7 @@ export default class EnvoyeMessenger implements Messenger {
     conversation: Conversation,
     senderId: number,
     content: string[],
+    sentAt: Date,
   ) {
     const message = content.join('\n');
     return this.prisma.message.create({
@@ -87,6 +92,7 @@ export default class EnvoyeMessenger implements Messenger {
         conversationId: conversation.id,
         authorId: senderId,
         content: message,
+        sentAt,
       },
     });
   }

--- a/src/conversations/messangers/messenger.ts
+++ b/src/conversations/messangers/messenger.ts
@@ -5,5 +5,6 @@ export default interface Messenger {
     conversationId: number,
     senderId: number,
     content: string[],
+    sentAt: Date,
   ): Promise<Message>;
 }

--- a/src/workspace/steps/create-self-conversation.spec.ts
+++ b/src/workspace/steps/create-self-conversation.spec.ts
@@ -90,6 +90,7 @@ describe('CreateSelfConversationStep', () => {
       tumise.id,
       workspace.code,
       [],
+      new Date(),
     );
 
     const workspaceDetails = await miniWorkspaceWithAdmin();

--- a/src/workspace/steps/create-self-conversation.ts
+++ b/src/workspace/steps/create-self-conversation.ts
@@ -25,6 +25,7 @@ export class CreateSelfConversationStep implements PostSetupStep {
       admin.id,
       admin.workspaceCode,
       [],
+      new Date(),
     );
 
     this.logger.log(

--- a/src/workspace/workspace-invite-service.ts
+++ b/src/workspace/workspace-invite-service.ts
@@ -137,6 +137,7 @@ export class WorkspaceInviteService {
         teammate.id,
         teammate.workspaceCode,
         [],
+        new Date(),
       );
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
## Summary

Sometimes, when a conversation is sent and when it is created in the DB might not be the same. Take, for instance, a user has network issues, it is quite possible that 

user attempts to send M1 - M2 - M3 . 

M1 fails, M3 gets sent to DB first, then M1 and M2. This shouldn't matter. We should maintain the expected order for the user.  What is the order of sending the message? 