### PR TITLE
Fix how we handle clock skew

### DIFF
--- a/src/conversations/conversations.controller.spec.ts
+++ b/src/conversations/conversations.controller.spec.ts
@@ -31,7 +31,7 @@ import { LinkService } from '@/common/link-service';
 import { mockConfigService } from '@/test-helpers/mocks';
 
 const validSentAt = new Date('2026-06-20T10:00:00.000Z');
-const futureSentAt = new Date(Date.now() + 60_000);
+const futureSentAt = new Date(Date.now() + 300_000);
 
 describe('ConversationsController', () => {
   let requestUser: RequestUser;

--- a/src/conversations/dto/send-message.dto.ts
+++ b/src/conversations/dto/send-message.dto.ts
@@ -11,6 +11,7 @@ import {
 } from 'class-validator';
 import MaxCharacterLimit from '@/common/validators/max-character-limit';
 import { MAX_ENVOYE_MESSAGE_CHARACTERS } from '@/conversations/const';
+import { addMinutes } from 'date-fns/addMinutes';
 
 export class SendTextMessageDto {
   @ApiProperty({ description: 'Workspace code', example: '12er56' })
@@ -45,6 +46,8 @@ export class SendTextMessageDto {
   @Type(() => Date)
   @IsDate()
   @IsNotEmpty()
-  @MaxDate(() => new Date(), { message: 'sentAt cannot be in the future' })
+  @MaxDate(() => addMinutes(Date.now(), 2), {
+    message: 'sentAt cannot be in the future',
+  }) // let's allow grace for clock skew.
   sentAt: Date;
 }


### PR DESCRIPTION
## Summary

I've been unable to send messages on my phone from Envoye.  😢 The first reason was that I turned off the network in my dev tool -classic.

Another seems to be that my phone clock is slightly ahead of server clock 😕  i don't quite understand this yet, but i get error 

<img width="780" height="270" alt="Screenshot 2026-06-30 at 22 25 16" src="https://github.com/user-attachments/assets/29ff1de8-32f2-40d6-9966-d28db9eeecc2" />

<img width="765" height="347" alt="Screenshot 2026-06-30 at 22 25 44" src="https://github.com/user-attachments/assets/5cc84703-d438-47d2-8f09-3ced7bad809c" />


Maybe it's just miliseconds ahead, but i've used 2 minutes here