### PR TITLE
Update conversation schema: Include `participant_signature`

### DIFF
--- a/prisma/migrations/20260704081252_add_participant_signature_to_conversation/migration.sql
+++ b/prisma/migrations/20260704081252_add_participant_signature_to_conversation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "conversation" ADD COLUMN     "participant_signature" TEXT;

--- a/prisma/migrations/20260704082548_add_index_to_participant_signature/migration.sql
+++ b/prisma/migrations/20260704082548_add_index_to_participant_signature/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "conversation_workspaceCode_participant_signature_idx" ON "conversation"("workspaceCode", "participant_signature");

--- a/prisma/migrations/20260704091900_update_column_name_perticipant_signature/migration.sql
+++ b/prisma/migrations/20260704091900_update_column_name_perticipant_signature/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `participant_signature` on the `conversation` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "conversation_workspaceCode_participant_signature_idx";
+
+-- DropIndex
+DROP INDEX "conversation_participant_conversationId_teammateId_idx";
+
+-- AlterTable
+ALTER TABLE "conversation" DROP COLUMN "participant_signature",
+ADD COLUMN     "participantSignature" TEXT;
+
+-- CreateIndex
+CREATE INDEX "conversation_workspaceCode_participantSignature_idx" ON "conversation"("workspaceCode", "participantSignature");

--- a/prisma/schemas/conversation.prisma
+++ b/prisma/schemas/conversation.prisma
@@ -19,5 +19,6 @@ model Conversation {
   messages                 Message[]
   conversationParticipants ConversationParticipant[]
 
+  @@index([workspaceCode, participant_signature])
   @@map("conversation")
 }

--- a/prisma/schemas/conversation.prisma
+++ b/prisma/schemas/conversation.prisma
@@ -7,7 +7,7 @@ enum ConversationStatus {
 
 model Conversation {
   id                       Int                       @id @default(autoincrement())
-  participant_signature    String?
+  participantSignature     String?
   workspaceCode            String                    @db.VarChar(6)
   workspace                Workspace                 @relation(fields: [workspaceCode], references: [code], onDelete: Cascade)
   status                   ConversationStatus        @default(OPEN)
@@ -19,6 +19,6 @@ model Conversation {
   messages                 Message[]
   conversationParticipants ConversationParticipant[]
 
-  @@index([workspaceCode, participant_signature])
+  @@index([workspaceCode, participantSignature])
   @@map("conversation")
 }

--- a/prisma/schemas/conversation.prisma
+++ b/prisma/schemas/conversation.prisma
@@ -7,6 +7,7 @@ enum ConversationStatus {
 
 model Conversation {
   id                       Int                       @id @default(autoincrement())
+  participant_signature    String?
   workspaceCode            String                    @db.VarChar(6)
   workspace                Workspace                 @relation(fields: [workspaceCode], references: [code], onDelete: Cascade)
   status                   ConversationStatus        @default(OPEN)


### PR DESCRIPTION
## Summary

Towards https://github.com/exwestafrican/wagz/issues/249

Before creating a conversation, we need to know if it already exists. This is particularly important for 1-on-1 conversations and one-user-only conversations. It's a bit complex and may be expensive to query the participant tables for conversations with fewer than or equal to 2 participants. 

We want to use this reference to make our lookup more efficient by using the app code and teammate IDs ( this has to be ordered). e.g w3pp01:32:42 We then simply need to do a lookup against this key. Which is way more efficient and easier to reproduce.


