### PR TITLE
Add index on Conversation participant table

### DIFF
--- a/prisma/schemas/conversation_participant.prisma
+++ b/prisma/schemas/conversation_participant.prisma
@@ -14,5 +14,6 @@ model ConversationParticipant {
 
   @@index([workspaceCode, teammateId])
   @@index([workspaceCode, conversationId])
+  @@index([conversationId, teammateId])
   @@map("conversation_participant")
 }


### PR DESCRIPTION
## Summary

Most of the lookups we do are with conversation and teammate ID. 

🤔 I don't think we need three indexes. We'll see how our query grows and trim the ones we don't need. 