### PR TITLE
Add new column and index `participantSignature` to Conversation table

### DIFF
--- a/prisma/migrations/20260704092344_add_participant_signature_to_conversation/migration.sql
+++ b/prisma/migrations/20260704092344_add_participant_signature_to_conversation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "conversation" ADD COLUMN     "participantSignature" TEXT;

--- a/prisma/migrations/20260704092432_add_index_on_participant_signature/migration.sql
+++ b/prisma/migrations/20260704092432_add_index_on_participant_signature/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "conversation_workspaceCode_participantSignature_idx" ON "conversation"("workspaceCode", "participantSignature");

--- a/prisma/schemas/conversation.prisma
+++ b/prisma/schemas/conversation.prisma
@@ -13,10 +13,12 @@ model Conversation {
   subject                  String?                   @db.VarChar(100)
   customerInfo             String?                   @db.VarChar(100)
   lastMessage              Int?
+  participantSignature     String?
   createdAt                DateTime                  @default(now())
   updatedAt                DateTime                  @updatedAt
   messages                 Message[]
   conversationParticipants ConversationParticipant[]
 
+  @@index([workspaceCode, participantSignature])
   @@map("conversation")
 }


### PR DESCRIPTION
## Summary

Towards https://github.com/exwestafrican/wagz/issues/249

Before creating a conversation, we need to know if it already exists. This is particularly important for 1-on-1 conversations and one-user-only conversations. It's a bit complex and may be expensive to query the participant tables for conversations with fewer than or equal to 2 participants. 

We want to use this reference to make our lookup more efficient by using the app code and teammate IDs ( this has to be ordered). e.g` w3pp01:32:42` We then simply need to do a lookup against this key. Which is way more efficient and easier to reproduce.