### PR TITLE
Backfill/update conversation participant signature

### DIFF
--- a/src/backfill/backfill-registry.provider.ts
+++ b/src/backfill/backfill-registry.provider.ts
@@ -1,13 +1,43 @@
-import { createTaskRegistry, registerBackfillTasks } from '@/backfill/task';
+import { createTaskRegistry } from '@/backfill/task';
+import { NormalizeUsernames } from '@/backfill/tasks/normalize-username';
+import { ConversationParticipantsSignature } from '@/backfill/tasks/participants-signature';
+import { PrismaService } from '@/prisma/prisma.service';
+import { ConversationsService } from '@/conversations/conversations.service';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { ConversationsModule } from '@/conversations/conversations.module';
 
 export const BACKFILL_REGISTRY = Symbol('BACKFILL_REGISTRY');
 export type Registry = ReturnType<typeof createTaskRegistry>;
 
 export const BackfillRegistryProvider = {
   provide: BACKFILL_REGISTRY,
-  useFactory: () => {
+  imports: [PrismaModule, ConversationsModule],
+  inject: [PrismaService, ConversationsService],
+  useFactory: (
+    prismaService: PrismaService,
+    ConversationsService: ConversationsService,
+  ) => {
     const registry = createTaskRegistry();
-    registerBackfillTasks(registry);
+    // TODO: add alerting if task is older than a month.
+    registry.register({
+      name: 'Backfill Normalize Usernames',
+      description:
+        'Removes special characters from username and stores in normalized format',
+      key: 'normalize_usernames',
+      task: new NormalizeUsernames(prismaService),
+      dateAdded: 1783166035, // 4th july 2026
+    });
+    registry.register({
+      name: 'Backfill Conversations with no participant signature',
+      description:
+        'Backfills all conversation with at least 2 participants. It adds a participant signature to conversation',
+      key: 'conversation_participant_signature',
+      task: new ConversationParticipantsSignature(
+        prismaService,
+        ConversationsService,
+      ),
+      dateAdded: 1783166035, // 4th july 2026
+    });
     return registry;
   },
 };

--- a/src/backfill/backfill.controller.spec.ts
+++ b/src/backfill/backfill.controller.spec.ts
@@ -22,6 +22,8 @@ import { ENVOYE_WORKSPACE_CODE } from '@/feature-flag/const';
 import { EMAIL_CLIENT, EmailClient } from '@/messaging/email/email-client';
 import { TeammatesService } from '@/teammates/teammates.service';
 import { resetDb } from '@/test-helpers/rest-db';
+import { ConversationsService } from '@/conversations/conversations.service';
+import { LinkService } from '@/common/link-service';
 
 describe('BackfillController', () => {
   let requestUser: RequestUser;
@@ -41,6 +43,8 @@ describe('BackfillController', () => {
         RoleService,
         PrismaService,
         TeammatesService,
+        ConversationsService,
+        LinkService,
         { provide: EMAIL_CLIENT, useValue: { send: sendMock } },
       ],
     }).with(requestUser);
@@ -71,7 +75,7 @@ describe('BackfillController', () => {
         .send()
         .expect(HttpStatus.OK);
       const body = response.body as BackfillResponseDto[];
-      expect(body.length).toBe(1);
+      expect(body.length).toBe(2);
     });
 
     it('should return 403 for when user is not super admin', async () => {

--- a/src/backfill/backfill.controller.ts
+++ b/src/backfill/backfill.controller.ts
@@ -14,6 +14,7 @@ import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { render } from '@react-email/render';
 import React from 'react';
 import { SupabaseAuthGuard } from '@/auth/guard/supabase.guard';
+import type BackfillTask from '@/backfill/task';
 import BackfillResponseDto, {
   toBackfillResponseDto,
 } from '@/backfill/dto/backfill-response.dto';
@@ -84,46 +85,48 @@ export class BackfillController {
       ENVOYE_WORKSPACE_CODE,
       PERMISSIONS.RUN_BACKFILL_TASK,
       async () => {
+        let task: BackfillTask;
         try {
-          const task = this.registry.get(jobId);
-          const workspaces = await this.prismaService.workspace.findMany({
-            orderBy: { id: 'asc' },
-          });
-
-          const failedWorkspaceCodes: string[] = [];
-          for (const workspace of workspaces) {
-            try {
-              await task.run(workspace);
-            } catch (error) {
-              failedWorkspaceCodes.push(workspace.code);
-              this.logger.error(
-                `Backfill job failed; jobId=${jobId} workspaceCode=${workspace.code}`,
-                error,
-              );
-            }
-          }
-
-          const jobSummary = buildJobRunSummary(
-            jobId,
-            workspaces,
-            failedWorkspaceCodes.length,
-          );
-
-          if (jobSummary.failed > 0) {
-            this.logger.error(
-              `Backfill job completed with failures; jobId=${jobId} failedWorkspaceCodes=[${failedWorkspaceCodes.join(', ')}]`,
-            );
-          }
-
-          const teammate = await this.teammateService.getMyTeammateProfile(
-            ENVOYE_WORKSPACE_CODE,
-            requestUser.email,
-          );
-          await this.sendCompletionEmail(teammate, jobSummary);
-          return toBackfillRunResponseDto(jobSummary);
+          task = this.registry.get(jobId);
         } catch {
           throw new NotFoundException(`Unknown backfill job: ${jobId}`);
         }
+
+        const workspaces = await this.prismaService.workspace.findMany({
+          orderBy: { id: 'asc' },
+        });
+
+        const failedWorkspaceCodes: string[] = [];
+        for (const workspace of workspaces) {
+          try {
+            await task.run(workspace);
+          } catch (error) {
+            failedWorkspaceCodes.push(workspace.code);
+            this.logger.error(
+              `Backfill job failed; jobId=${jobId} workspaceCode=${workspace.code}`,
+              error,
+            );
+          }
+        }
+
+        const jobSummary = buildJobRunSummary(
+          jobId,
+          workspaces,
+          failedWorkspaceCodes.length,
+        );
+
+        if (jobSummary.failed > 0) {
+          this.logger.error(
+            `Backfill job completed with failures; jobId=${jobId} failedWorkspaceCodes=[${failedWorkspaceCodes.join(', ')}]`,
+          );
+        }
+
+        const teammate = await this.teammateService.getMyTeammateProfile(
+          ENVOYE_WORKSPACE_CODE,
+          requestUser.email,
+        );
+        await this.sendCompletionEmail(teammate, jobSummary);
+        return toBackfillRunResponseDto(jobSummary);
       },
     );
   }

--- a/src/backfill/backfill.controller.ts
+++ b/src/backfill/backfill.controller.ts
@@ -85,48 +85,46 @@ export class BackfillController {
       ENVOYE_WORKSPACE_CODE,
       PERMISSIONS.RUN_BACKFILL_TASK,
       async () => {
-        let task: BackfillTask;
         try {
-          task = this.registry.get(jobId, this.prismaService);
+          const task = this.registry.get(jobId);
+          const workspaces = await this.prismaService.workspace.findMany({
+            orderBy: { id: 'asc' },
+          });
+
+          const failedWorkspaceCodes: string[] = [];
+          for (const workspace of workspaces) {
+            try {
+              await task.run(workspace);
+            } catch (error) {
+              failedWorkspaceCodes.push(workspace.code);
+              this.logger.error(
+                `Backfill job failed; jobId=${jobId} workspaceCode=${workspace.code}`,
+                error,
+              );
+            }
+          }
+
+          const jobSummary = buildJobRunSummary(
+            jobId,
+            workspaces,
+            failedWorkspaceCodes.length,
+          );
+
+          if (jobSummary.failed > 0) {
+            this.logger.error(
+              `Backfill job completed with failures; jobId=${jobId} failedWorkspaceCodes=[${failedWorkspaceCodes.join(', ')}]`,
+            );
+          }
+
+          const teammate = await this.teammateService.getMyTeammateProfile(
+            ENVOYE_WORKSPACE_CODE,
+            requestUser.email,
+          );
+          await this.sendCompletionEmail(teammate, jobSummary);
+          return toBackfillRunResponseDto(jobSummary);
         } catch {
           throw new NotFoundException(`Unknown backfill job: ${jobId}`);
         }
-
-        const workspaces = await this.prismaService.workspace.findMany({
-          orderBy: { id: 'asc' },
-        });
-
-        const failedWorkspaceCodes: string[] = [];
-        for (const workspace of workspaces) {
-          try {
-            await task.run(workspace);
-          } catch (error) {
-            failedWorkspaceCodes.push(workspace.code);
-            this.logger.error(
-              `Backfill job failed; jobId=${jobId} workspaceCode=${workspace.code}`,
-              error,
-            );
-          }
-        }
-
-        const jobSummary = buildJobRunSummary(
-          jobId,
-          workspaces,
-          failedWorkspaceCodes.length,
-        );
-
-        if (jobSummary.failed > 0) {
-          this.logger.error(
-            `Backfill job completed with failures; jobId=${jobId} failedWorkspaceCodes=[${failedWorkspaceCodes.join(', ')}]`,
-          );
-        }
-
-        const teammate = await this.teammateService.getMyTeammateProfile(
-          ENVOYE_WORKSPACE_CODE,
-          requestUser.email,
-        );
-        await this.sendCompletionEmail(teammate, jobSummary);
-        return toBackfillRunResponseDto(jobSummary);
       },
     );
   }

--- a/src/backfill/backfill.controller.ts
+++ b/src/backfill/backfill.controller.ts
@@ -14,7 +14,6 @@ import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { render } from '@react-email/render';
 import React from 'react';
 import { SupabaseAuthGuard } from '@/auth/guard/supabase.guard';
-import type BackfillTask from '@/backfill/task';
 import BackfillResponseDto, {
   toBackfillResponseDto,
 } from '@/backfill/dto/backfill-response.dto';

--- a/src/backfill/backfill.module.ts
+++ b/src/backfill/backfill.module.ts
@@ -5,9 +5,15 @@ import { BackfillController } from './backfill.controller';
 import { BackfillRegistryProvider } from '@/backfill/backfill-registry.provider';
 import { PermissionModule } from '@/permission/permission.module';
 import { TeammatesModule } from '@/teammates/teammates.module';
+import { ConversationsModule } from '@/conversations/conversations.module';
 
 @Module({
-  imports: [PrismaModule, PermissionModule, TeammatesModule],
+  imports: [
+    PrismaModule,
+    PermissionModule,
+    TeammatesModule,
+    ConversationsModule,
+  ],
   providers: [NormalizeUsernames, BackfillRegistryProvider],
   controllers: [BackfillController],
 })

--- a/src/backfill/task.ts
+++ b/src/backfill/task.ts
@@ -1,6 +1,4 @@
 import { Workspace } from '@/generated/prisma/client';
-import { PrismaService } from '@/prisma/prisma.service';
-import { NormalizeUsernames } from '@/backfill/tasks/normalize-username';
 
 export default interface BackfillTask {
   run(workspace: Workspace): Promise<void>;
@@ -9,7 +7,7 @@ export default interface BackfillTask {
 type TaskEntry = {
   name: string;
   description: string;
-  create: (prisma: PrismaService) => BackfillTask;
+  task: BackfillTask;
 };
 
 export type TaskDetails = {
@@ -25,21 +23,22 @@ export function createTaskRegistry() {
       name: string;
       description: string;
       key: string;
-      Task: new (prisma: PrismaService) => BackfillTask;
+      dateAdded: number;
+      task: BackfillTask;
     }) => {
       registeredTasks[detail.key] = {
         name: detail.name,
         description: detail.description,
-        create: (prisma: PrismaService) => new detail.Task(prisma),
+        task: detail.task,
       };
     },
 
-    get: (key: string, prisma: PrismaService) => {
-      const task = registeredTasks[key];
-      if (!task) {
+    get: (key: string) => {
+      const taskEntry = registeredTasks[key];
+      if (!taskEntry) {
         throw new Error('Task not registered');
       }
-      return task.create(prisma);
+      return taskEntry.task;
     },
 
     all: () => {
@@ -50,16 +49,4 @@ export function createTaskRegistry() {
       }));
     },
   };
-}
-
-export function registerBackfillTasks(
-  registry: ReturnType<typeof createTaskRegistry>,
-) {
-  registry.register({
-    name: 'Backfill Normalize Usernames',
-    description:
-      'Removes special characters from username and stores in normalized format',
-    key: 'normalize_usernames',
-    Task: NormalizeUsernames,
-  });
 }

--- a/src/backfill/tasks/participant-signature.spec.ts
+++ b/src/backfill/tasks/participant-signature.spec.ts
@@ -108,14 +108,14 @@ describe(' Conversation Participant Signature Backfill Task', () => {
     const conversation = await createConversationWithOwner(sammy);
     await addOtherParticipants(conversation, [derick]);
 
-    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    await assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
       1,
       workspace.code,
     );
 
     await service.run(workspace);
 
-    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    await assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
       0,
       workspace.code,
     );
@@ -131,14 +131,14 @@ describe(' Conversation Participant Signature Backfill Task', () => {
 
     await createConversationWithOwner(dammy);
 
-    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    await assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
       1,
       workspace.code,
     );
 
     await service.run(workspace);
 
-    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    await assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
       0,
       workspace.code,
     );
@@ -157,14 +157,14 @@ describe(' Conversation Participant Signature Backfill Task', () => {
     const conversation = await createConversationWithOwner(vivian);
     await addOtherParticipants(conversation, [joy, tomi]);
 
-    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    await assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
       1,
       workspace.code,
     );
 
     await service.run(workspace);
 
-    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    await assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
       1,
       workspace.code,
     );

--- a/src/backfill/tasks/participant-signature.spec.ts
+++ b/src/backfill/tasks/participant-signature.spec.ts
@@ -1,0 +1,172 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '@/prisma/prisma.service';
+import Factory, { PersistStrategy } from '@/factories/factory';
+import { ConversationsService } from '@/conversations/conversations.service';
+import { ConversationParticipantsSignature } from '@/backfill/tasks/participants-signature';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { createTestApp } from '@/test-helpers/test-app';
+import { LinkService } from '@/common/link-service';
+import { mockConfigService } from '@/test-helpers/mocks';
+import { TestEmailClient } from '@/messaging/email/test-email-client';
+import { resetDb } from '@/test-helpers/rest-db';
+import { setupWorkspaceWithMultipleTeammates } from '@/test-helpers/workspace-helpers';
+import { Conversation, Teammate } from '@/generated/prisma/client';
+
+//TODO: add date added to backfill taks
+describe(' Conversation Participant Signature Backfill Task', () => {
+  let app: INestApplication;
+  let prismaService: PrismaService;
+  let factory: PersistStrategy;
+  let conversationService: ConversationsService;
+  let service: ConversationParticipantsSignature;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot(), PrismaModule],
+      providers: [],
+    }).compile();
+
+    app = await createTestApp(module);
+    prismaService = app.get<PrismaService>(PrismaService);
+    factory = Factory.createStrategy(prismaService);
+    const linkService = new LinkService(mockConfigService);
+    conversationService = new ConversationsService(
+      prismaService,
+      new TestEmailClient(),
+      linkService,
+    );
+    service = new ConversationParticipantsSignature(
+      prismaService,
+      conversationService,
+    );
+  });
+
+  afterEach(async () => {
+    await resetDb(prismaService);
+    await app.close();
+  });
+
+  async function createConversationWithOwner(owner: Teammate) {
+    const conversation = await prismaService.conversation.create({
+      data: {
+        workspaceCode: owner.workspaceCode,
+      },
+    });
+
+    await prismaService.conversationParticipant.create({
+      data: {
+        workspaceCode: owner.workspaceCode,
+        conversationId: conversation.id,
+        teammateId: owner.id,
+        isOwner: true,
+      },
+    });
+
+    return conversation;
+  }
+
+  async function addOtherParticipants(
+    conversation: Conversation,
+    participants: Teammate[],
+  ) {
+    const data = participants.map((participant) => {
+      return {
+        workspaceCode: conversation.workspaceCode,
+        conversationId: conversation.id,
+        teammateId: participant.id,
+      };
+    });
+    await prismaService.conversationParticipant.createMany({
+      data: data,
+    });
+  }
+
+  async function assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+    count: number,
+    workspaceCode: string,
+  ) {
+    const conversations = await prismaService.conversation.findMany({
+      where: { workspaceCode: workspaceCode },
+    });
+
+    expect(
+      conversations.filter((c) => c.participantSignature === null).length,
+    ).toBe(count);
+  }
+
+  test('it updates participant signature when only two participants', async () => {
+    const { workspace, teammates } = await setupWorkspaceWithMultipleTeammates(
+      factory,
+      5,
+    );
+
+    const sammy = teammates[0];
+    const derick = teammates[1];
+
+    const conversation = await createConversationWithOwner(sammy);
+    await addOtherParticipants(conversation, [derick]);
+
+    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+      1,
+      workspace.code,
+    );
+
+    await service.run(workspace);
+
+    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+      0,
+      workspace.code,
+    );
+  });
+
+  it('updates participant signature when only one ', async () => {
+    const { workspace, teammates } = await setupWorkspaceWithMultipleTeammates(
+      factory,
+      5,
+    );
+
+    const dammy = teammates[2];
+
+    await createConversationWithOwner(dammy);
+
+    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+      1,
+      workspace.code,
+    );
+
+    await service.run(workspace);
+
+    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+      0,
+      workspace.code,
+    );
+  });
+
+  it('does not backfill conversations with more than two participants', async () => {
+    const { workspace, teammates } = await setupWorkspaceWithMultipleTeammates(
+      factory,
+      5,
+    );
+
+    const vivian = teammates[0];
+    const joy = teammates[1];
+    const tomi = teammates[2];
+
+    const conversation = await createConversationWithOwner(vivian);
+    await addOtherParticipants(conversation, [joy, tomi]);
+
+    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+      1,
+      workspace.code,
+    );
+
+    await service.run(workspace);
+
+    assertConversationWithMissingParticipantSignatureCountForWorkspaceIsExpectedNumber(
+      1,
+      workspace.code,
+    );
+  });
+});

--- a/src/backfill/tasks/participants-signature.ts
+++ b/src/backfill/tasks/participants-signature.ts
@@ -1,0 +1,51 @@
+import BackfillTask from '@/backfill/task';
+import { Logger } from '@nestjs/common';
+import { Workspace } from '@/generated/prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
+import { ConversationsService } from '@/conversations/conversations.service';
+
+export class ConversationParticipantsSignature implements BackfillTask {
+  logger = new Logger(ConversationParticipantsSignature.name);
+
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly conversationService: ConversationsService,
+  ) {}
+
+  async run(workspace: Workspace): Promise<void> {
+    // fetch all conversations if participant count <=2 run logic
+    const conversations = await this.prismaService.conversation.findMany({
+      where: {
+        workspaceCode: workspace.code,
+      },
+    });
+
+    for (const conversation of conversations) {
+      const participants =
+        await this.prismaService.conversationParticipant.findMany({
+          where: {
+            workspaceCode: conversation.workspaceCode,
+            conversationId: conversation.id,
+          },
+        });
+      if (participants.length <= 2) {
+        const signature = this.conversationService.participantSignature(
+          workspace.code,
+          participants,
+        );
+        await this.prismaService.conversation.update({
+          where: { id: conversation.id },
+          data: { participantSignature: signature },
+        });
+
+        this.logger.log(
+          `updated conversation signature; conversationId=${conversation.id} participantSignature=${signature} `,
+        );
+      } else {
+        this.logger.log(
+          `skipping conversation with more than 2 participants; conversationId=${conversation.id} participantCount=${participants.length}`,
+        );
+      }
+    }
+  }
+}

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -1,7 +1,10 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import { notInDbError } from '@/common/error-type';
-import { Teammate } from '@/generated/prisma/client';
+import {
+  ConversationParticipant,
+  Teammate,
+} from '@/generated/prisma/client';
 import { render } from '@react-email/render';
 import NewMessageNotificationTemplate from '@/emails/templates/new-message-notification.template';
 import React from 'react';
@@ -93,5 +96,15 @@ export class ConversationsService {
         html: emailHtml,
       });
     }
+  }
+
+  participantSignature(
+    workspaceCode: string,
+    participants: ConversationParticipant[],
+  ) {
+    const teammateIds = participants
+      .map((participant) => participant.teammateId)
+      .sort();
+    return [workspaceCode, teammateIds].join(':');
   }
 }

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -101,7 +101,7 @@ export class ConversationsService {
   ) {
     const teammateIds = participants
       .map((participant) => participant.teammateId)
-      .sort();
+      .sort((a, b) => a - b); //ascending order
     return [workspaceCode, teammateIds].join(':');
   }
 }

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -1,10 +1,7 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import { notInDbError } from '@/common/error-type';
-import {
-  ConversationParticipant,
-  Teammate,
-} from '@/generated/prisma/client';
+import { ConversationParticipant, Teammate } from '@/generated/prisma/client';
 import { render } from '@react-email/render';
 import NewMessageNotificationTemplate from '@/emails/templates/new-message-notification.template';
 import React from 'react';

--- a/src/conversations/messangers/envoye.spec.ts
+++ b/src/conversations/messangers/envoye.spec.ts
@@ -11,13 +11,10 @@ import {
   setupWorkspaceWithTeammate,
 } from '@/test-helpers/workspace-helpers';
 import EnvoyeMessenger from '@/conversations/messangers/envoye';
-import {
-  Conversation,
-  ConversationStatus,
-  Workspace,
-} from '@/generated/prisma/client';
+import { ConversationStatus } from '@/generated/prisma/client';
 import { resetDb } from '@/test-helpers/rest-db';
 import { addMinutes } from 'date-fns/addMinutes';
+import { singeParticipantMessageHistory } from '@/test-helpers/messaging.helpers';
 
 describe('EnvoyeMessenger', () => {
   let messenger: EnvoyeMessenger;
@@ -41,43 +38,6 @@ describe('EnvoyeMessenger', () => {
     await resetDb(prismaService);
     await app.close();
   });
-
-  type MessageHistory = {
-    senderId: number;
-    messages: string[];
-    sentAt: Date;
-  };
-
-  async function singeParticipantMessageHistory(
-    workspace: Workspace,
-    chatHistory: MessageHistory[],
-  ): Promise<Conversation> {
-    const openingMessage = chatHistory[0];
-    const otherMessages = chatHistory.slice(1);
-    const recipientReply: MessageHistory | undefined = chatHistory.find(
-      (h) => h.senderId !== openingMessage.senderId,
-    );
-
-    const recipientId = recipientReply?.senderId ?? 0;
-
-    const conversation = await messenger.sendOpeningTextMessage(
-      openingMessage.senderId,
-      recipientId,
-      workspace.code,
-      openingMessage.messages,
-      openingMessage.sentAt,
-    );
-
-    for (const history of otherMessages) {
-      await messenger.sendTextMessage(
-        conversation.id,
-        history.senderId,
-        history.messages,
-        history.sentAt,
-      );
-    }
-    return conversation;
-  }
 
   describe('sendOpeningTextMessage', () => {
     it('creates an open conversation with the teammate as sole owner participant', async () => {
@@ -216,6 +176,7 @@ describe('EnvoyeMessenger', () => {
 
       const conversation = await singeParticipantMessageHistory(
         workspace,
+        messenger,
         chatHistory,
       );
 
@@ -243,6 +204,7 @@ describe('EnvoyeMessenger', () => {
 
       const conversation = await singeParticipantMessageHistory(
         workspace,
+        messenger,
         chatHistory,
       );
 

--- a/src/conversations/messangers/messenger.ts
+++ b/src/conversations/messangers/messenger.ts
@@ -1,7 +1,15 @@
 import { type Message as DomainMessage } from '@/conversations/domain/message';
-import { type Message } from '@/generated/prisma/client';
+import { Conversation, type Message } from '@/generated/prisma/client';
 
 export default interface Messenger {
+  sendOpeningTextMessage(
+    senderId: number,
+    recipientTeammateId: number,
+    workspaceCode: string,
+    openingMessage: string[],
+    sentAt: Date,
+  ): Promise<Conversation>;
+
   sendTextMessage(
     conversationId: number,
     senderId: number,

--- a/src/test-helpers/messaging.helpers.ts
+++ b/src/test-helpers/messaging.helpers.ts
@@ -1,0 +1,40 @@
+import { Conversation, Workspace } from '@/generated/prisma/client';
+import Messenger from '@/conversations/messangers/messenger';
+
+export type MessageHistory = {
+  senderId: number;
+  messages: string[];
+  sentAt: Date;
+};
+
+export async function singeParticipantMessageHistory(
+  workspace: Workspace,
+  messenger: Messenger,
+  chatHistory: MessageHistory[],
+): Promise<Conversation> {
+  const openingMessage = chatHistory[0];
+  const otherMessages = chatHistory.slice(1);
+  const recipientReply: MessageHistory | undefined = chatHistory.find(
+    (h) => h.senderId !== openingMessage.senderId,
+  );
+
+  const recipientId = recipientReply?.senderId ?? 0;
+
+  const conversation = await messenger.sendOpeningTextMessage(
+    openingMessage.senderId,
+    recipientId,
+    workspace.code,
+    openingMessage.messages,
+    openingMessage.sentAt,
+  );
+
+  for (const history of otherMessages) {
+    await messenger.sendTextMessage(
+      conversation.id,
+      history.senderId,
+      history.messages,
+      history.sentAt,
+    );
+  }
+  return conversation;
+}


### PR DESCRIPTION
## Summary 

We registered a new backfill task 👇  to correct conversations that have no participant signature set 

<img width="1692" height="591" alt="Screenshot 2026-07-04 at 13 29 53" src="https://github.com/user-attachments/assets/a48d261b-0e52-43d1-8927-7df75a7244aa" />


I also did a quick improvement on how we register backfill tasks. Before, we could only register PrismaService; now we can inject anything we want. 😅 
