### PR TITLE
Fix how we sign conversations

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -16,9 +16,7 @@ import { SignupEmailDto } from './dto/signup.dto';
 import { AccountExistsException } from './exceptions/account.exists';
 import ApiBadRequestResponse from '@/common/decorators/bad-response';
 import { OtpVerificationDto } from './dto/otp-verification.dto';
-import {
-  OtpVerificationResponseDto,
-} from '@/auth/dto/otp-verification-response.dto';
+import { OtpVerificationResponseDto } from '@/auth/dto/otp-verification-response.dto';
 
 @Controller('auth')
 @ApiTags('auth')

--- a/src/conversations/conversations.service.ts
+++ b/src/conversations/conversations.service.ts
@@ -97,6 +97,6 @@ export class ConversationsService {
 
   participantSignature(workspaceCode: string, teammateIds: number[]) {
     const sortedTeammateIDs = teammateIds.sort((a, b) => a - b); //ascending order
-    return [workspaceCode, sortedTeammateIDs].join(':');
+    return [workspaceCode, ...sortedTeammateIDs].join(':');
   }
 }

--- a/src/conversations/messangers/envoye.spec.ts
+++ b/src/conversations/messangers/envoye.spec.ts
@@ -180,8 +180,25 @@ describe('EnvoyeMessenger', () => {
       );
 
       expect(conversation.participantSignature).toBe(
-        `${workspace.code}:${lowerTeammateId},${higherTeammateId}`,
+        `${workspace.code}:${lowerTeammateId}:${higherTeammateId}`,
       );
+    });
+
+    it('does not create signature when participants are more than 2', async () => {
+      const { workspace, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 4);
+
+      const [dan, marvin, tomisin] = teammates.slice(0, 3);
+
+      const conversation = await messenger.sendOpeningTextMessage(
+        marvin.id,
+        [dan.id, tomisin.id],
+        workspace.code,
+        [],
+        new Date(),
+      );
+
+      expect(conversation.participantSignature).toBe(null);
     });
   });
 

--- a/src/conversations/messangers/envoye.ts
+++ b/src/conversations/messangers/envoye.ts
@@ -94,13 +94,17 @@ export default class EnvoyeMessenger implements Messenger {
     const participantIds = Array.from(
       new Set([senderId, ...recipientTeammateIds]),
     );
+    const participantSignature =
+      participantIds.length <= 2
+        ? this.conversationsService.participantSignature(
+            workspaceCode,
+            participantIds,
+          )
+        : null;
     const conversation = await this.prisma.conversation.create({
       data: {
         workspaceCode: workspaceCode,
-        participantSignature: this.conversationsService.participantSignature(
-          workspaceCode,
-          participantIds,
-        ),
+        participantSignature: participantSignature,
       },
     });
 


### PR DESCRIPTION
## Summary

I noticed two things: the signature doesn't look right here, and we seem to be signing conversations with more than two participants. 

<img width="1180" height="165" alt="Screenshot 2026-07-10 at 09 01 29" src="https://github.com/user-attachments/assets/18de5a09-ad05-42ce-8f5d-b856d3988a5a" />

The signature should be delimited by ":" and not ","