### PR TITLE
Update config so we can auto-renewed certificate. Update instructions for setting up server so it's easy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
   nginx:
     container_name: envoye-nginx
     image: nginx:latest
+    restart: always
     ports:
       - '80:80'
       - '443:443'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,38 +1,14 @@
 server {
     listen 80;
-    server_name api.envoye.co localhost;
+    server_name api.envoye.co;
 
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
 
-    # For api.envoye.co, redirect to HTTPS
-    if ($host = api.envoye.co) {
-        return 301 https://$server_name$request_uri;
-    }
-
-
     location / {
-        proxy_pass http://app:3001;
-
-        # Client information
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Port $server_port;
-
-
-    # Forward client browser and session information
-        proxy_set_header User-Agent $http_user_agent;
-        proxy_set_header Cookie $http_cookie;
-        proxy_set_header Accept-Language $http_accept_language;
-        proxy_set_header Referer $http_referer;
-
-        # Forward client auth data
-        proxy_set_header Authorization $http_authorization;
-
+        return 301 https://$host$request_uri; # let https handle this
     }
 }
 
@@ -49,6 +25,37 @@ server {
 
     location / {
         proxy_pass http://app:3001;
+
+        # Client information
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme; # we expect this to be https
+        proxy_set_header X-Forwarded-Port $server_port;
+
+
+        # Forward client browser and session information
+        proxy_set_header User-Agent $http_user_agent;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Accept-Language $http_accept_language;
+        proxy_set_header Referer $http_referer;
+
+        # Forward client auth data
+        proxy_set_header Authorization $http_authorization;
+    }
+}
+
+# HTTPS server - localhost only config
+server {
+    listen 80;
+    server_name localhost;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+       proxy_pass http://app:3001;
 
         # Client information
         proxy_set_header Host $host;

--- a/scripts/instances/README.md
+++ b/scripts/instances/README.md
@@ -1,0 +1,26 @@
+after setting up server, we need to renew https
+we can do that with cert bot renew command
+
+But after it auto-renews, it needs nginx to use new certificate
+to do that,
+
+Check if Post deploy hook  exists. this command runs after the certificate is renewed 
+
+```aiignore
+$ sudo grep -R "deploy-hook" /etc/letsencrypt
+```
+
+if it doesn't exist, lets add it 
+
+```aiignore
+$ sudo vi /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+```
+
+paste contents in `post-renew-hook.sh`
+
+then run
+
+```aiignore
+$ sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+```
+

--- a/scripts/instances/post-renew-hook.sh
+++ b/scripts/instances/post-renew-hook.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec envoye-nginx nginx -s reload


### PR DESCRIPTION
## Summary

Our HTTPS didn't auto-renew because of bad config. 😅 I didn't know alot about the setup at the time, but i'm a bit wiser now, with the help of GPT and google. This is still a pretty simple config but i've broken it down for localhost and api. 

So now it should auto renew after we merge this and i run it one time manually. 


Towards https://github.com/exwestafrican/wagz/issues/133