### PR TITLE
Fix wrong signature

### DIFF
--- a/src/backfill/tasks/participants-signature.ts
+++ b/src/backfill/tasks/participants-signature.ts
@@ -45,6 +45,10 @@ export class ConversationParticipantsSignature implements BackfillTask {
           `updated conversation signature; conversationId=${conversation.id} participantSignature=${signature} `,
         );
       } else {
+        await this.prismaService.conversation.update({
+          where: { id: conversation.id },
+          data: { participantSignature: null },
+        });
         this.logger.log(
           `skipping conversation with more than 2 participants; conversationId=${conversation.id} participantCount=${participants.length}`,
         );


### PR DESCRIPTION
For conversations with multiple participants, we don't want to set it. 