### PR TITLE
Ensure we don't have duplicate conversation for simple Dm interactions

### DIFF
--- a/.cursor/rules/nest-spec-setup.mdc
+++ b/.cursor/rules/nest-spec-setup.mdc
@@ -38,6 +38,29 @@ controller = new ConversationsController(
 - Listing service classes in `providers: [ConversationsService, TeammatesService, ...]`
 - Two-phase module compiles just to wire `useValue` providers
 - `TestControllerModuleWithAuthUser` when testing controller/service logic directly
+- Spying on internal call order or method invocation (e.g. `jest.spyOn(prismaService.*, 'findFirst')` + `invocationCallOrder`) when behavioral tests already cover the outcome
+
+## Prefer behavioral assertions
+
+Test observable outcomes — thrown exceptions, persisted state, returned values — not how the implementation reaches them.
+
+```typescript
+// ❌ BAD — asserts implementation detail; duplicates behavioral coverage
+const findFirstSpy = jest.spyOn(prismaService.conversation, 'findFirst');
+const createSpy = jest.spyOn(prismaService.conversation, 'create');
+await messenger.sendOpeningTextMessage(...);
+expect(findFirstSpy.mock.invocationCallOrder[0]).toBeLessThan(
+  createSpy.mock.invocationCallOrder[0],
+);
+
+// ✅ GOOD — asserts the behavior users depend on
+await expect(messenger.sendOpeningTextMessage(...)).rejects.toBeInstanceOf(
+  ConflictException,
+);
+expect(await prismaService.conversation.count({ where: { workspaceCode } })).toBe(1);
+```
+
+Reserve spies/mocks for isolating external boundaries (email clients, HTTP, third-party SDKs), not for verifying that one internal method ran before another.
 
 ## Invoke the unit under test directly
 

--- a/src/conversations/conversations.controller.spec.ts
+++ b/src/conversations/conversations.controller.spec.ts
@@ -5,6 +5,7 @@ import RequestUser from '@/auth/domain/request-user';
 import {
   BadRequestException,
   ForbiddenException,
+  HttpStatus,
   INestApplication,
   NotFoundException,
 } from '@nestjs/common';
@@ -231,6 +232,38 @@ describe('ConversationsController', () => {
           sentAt: validSentAt,
         }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ConflictException when an ongoing conversation already exists', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+      await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [ROLES.WorkspaceMember.code],
+        },
+      });
+      const marvin = teammates[1];
+
+      const directMessagePayload = {
+        workspaceCode: koboMart.code,
+        recipientTeammateId: marvin.id,
+        openingMessage: ['Hey, how are you feeling.'],
+        sentAt: validSentAt,
+      };
+
+      await controller.createDirectMessage(requestUser, directMessagePayload);
+
+      await expect(
+        controller.createDirectMessage(requestUser, directMessagePayload),
+      ).rejects.toMatchObject({ status: HttpStatus.CONFLICT });
+
+      expect(
+        await prismaService.conversation.count({
+          where: { workspaceCode: koboMart.code },
+        }),
+      ).toBe(1);
     });
 
     it('persists opening message with client-provided sentAt', async () => {

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -104,6 +104,11 @@ export class ConversationsController {
     status: HttpStatus.NOT_FOUND,
     description: 'Recipient teammate not found',
   })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description:
+      'An ongoing conversation with these participants already exists',
+  })
   @UseGuards(SupabaseAuthGuard)
   async createDirectMessage(
     @User() requestUser: RequestUser,

--- a/src/conversations/messangers/envoye.spec.ts
+++ b/src/conversations/messangers/envoye.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
-import { INestApplication } from '@nestjs/common';
+import { ConflictException, INestApplication } from '@nestjs/common';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { PrismaService } from '@/prisma/prisma.service';
 import { createTestApp } from '@/test-helpers/test-app';
@@ -199,6 +199,67 @@ describe('EnvoyeMessenger', () => {
       );
 
       expect(conversation.participantSignature).toBe(null);
+    });
+
+    it('throws ConflictException when an ongoing two-participant conversation already exists', async () => {
+      const { workspace, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+      const [dan, marvin] = teammates;
+
+      await messenger.sendOpeningTextMessage(
+        dan.id,
+        [marvin.id],
+        workspace.code,
+        [],
+        new Date(),
+      );
+
+      await expect(
+        messenger.sendOpeningTextMessage(
+          marvin.id,
+          [dan.id],
+          workspace.code,
+          [],
+          new Date(),
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(
+        await prismaService.conversation.count({
+          where: { workspaceCode: workspace.code },
+        }),
+      ).toBe(1);
+    });
+
+    it('throws ConflictException when a self-conversation already exists', async () => {
+      const { workspace, teammate } = await setupWorkspaceWithTeammate(
+        factory,
+        teammateFactory.build({ email: 'owner@useenvoye.com' }),
+      );
+
+      await messenger.sendOpeningTextMessage(
+        teammate.id,
+        [teammate.id],
+        workspace.code,
+        [],
+        new Date(),
+      );
+
+      await expect(
+        messenger.sendOpeningTextMessage(
+          teammate.id,
+          [teammate.id],
+          workspace.code,
+          [],
+          new Date(),
+        ),
+      ).rejects.toBeInstanceOf(ConflictException);
+
+      expect(
+        await prismaService.conversation.count({
+          where: { workspaceCode: workspace.code },
+        }),
+      ).toBe(1);
     });
   });
 

--- a/src/conversations/messangers/envoye.ts
+++ b/src/conversations/messangers/envoye.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import Messenger from '@/conversations/messangers/messenger';
 import { Conversation, Message } from '@/generated/prisma/client';
@@ -11,6 +11,8 @@ import { ConversationsService } from '@/conversations/conversations.service';
 
 @Injectable()
 export default class EnvoyeMessenger implements Messenger {
+  logger = new Logger(EnvoyeMessenger.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly conversationsService: ConversationsService,
@@ -84,6 +86,28 @@ export default class EnvoyeMessenger implements Messenger {
     return messages.map((message) => toDomainMessage(message)).reverse();
   }
 
+  private async enforceNoOngoingConversation(
+    workspaceCode: string,
+    senderId: number,
+    participantIds: number[],
+  ) {
+    const signature = this.conversationsService.participantSignature(
+      workspaceCode,
+      participantIds,
+    );
+
+    const conversationExists = await this.prisma.conversation.findFirst({
+      where: { participantSignature: signature },
+    });
+
+    if (conversationExists) {
+      this.logger.warn(
+        `attempt to start new conversation when ongoing exists; workspaceCode=${workspaceCode}, senderId=${senderId}, participantIds=${participantIds.join(',')} `,
+      );
+      throw new ConflictException('Ongoing conversation exists');
+    }
+  }
+
   async sendOpeningTextMessage(
     senderId: number,
     recipientTeammateIds: number[],
@@ -94,6 +118,14 @@ export default class EnvoyeMessenger implements Messenger {
     const participantIds = Array.from(
       new Set([senderId, ...recipientTeammateIds]),
     );
+    //TODO: check that participants are less
+    if (participantIds.length <= 2) {
+      await this.enforceNoOngoingConversation(
+        workspaceCode,
+        senderId,
+        participantIds,
+      );
+    }
     const participantSignature =
       participantIds.length <= 2
         ? this.conversationsService.participantSignature(


### PR DESCRIPTION
## Summary

Towards https://github.com/exwestafrican/wagz/issues/249 . Now we've run backfill, so we can enforce checking if a conversation is potentially a duplicate. 