### PR TITLE
Clean up change for backward compatibility

### DIFF
--- a/src/conversations/conversations.controller.spec.ts
+++ b/src/conversations/conversations.controller.spec.ts
@@ -94,7 +94,7 @@ describe('ConversationsController', () => {
 
       const body = await controller.createDirectMessage(requestUser, {
         workspaceCode: koboMart.code,
-        recipientTeammateId: marvin.id,
+        recipientTeammateIds: [marvin.id],
         openingMessage: ['Hey, how are you feeling.'],
         sentAt: validSentAt,
       });
@@ -125,7 +125,7 @@ describe('ConversationsController', () => {
 
       const body = await controller.createDirectMessage(requestUser, {
         workspaceCode: koboMart.code,
-        recipientTeammateId: dan.id,
+        recipientTeammateIds: [dan.id],
         openingMessage: ['in the office today?'],
         sentAt: validSentAt,
       });
@@ -163,7 +163,7 @@ describe('ConversationsController', () => {
       await expect(
         controller.createDirectMessage(requestUser, {
           workspaceCode: koboMart.code,
-          recipientTeammateId: marvinInZuriBakery.id,
+          recipientTeammateIds: [marvinInZuriBakery.id],
           openingMessage: ['wagwan G!'],
           sentAt: validSentAt,
         }),
@@ -187,7 +187,7 @@ describe('ConversationsController', () => {
       await expect(
         controller.createDirectMessage(requestUser, {
           workspaceCode: '345dv5',
-          recipientTeammateId: marvin.id,
+          recipientTeammateIds: [marvin.id],
           openingMessage: ['Welcome to Envoye!'],
           sentAt: validSentAt,
         }),
@@ -206,7 +206,7 @@ describe('ConversationsController', () => {
       await expect(
         controller.createDirectMessage(requestUser, {
           workspaceCode: koboMart.code,
-          recipientTeammateId: marvin.id,
+          recipientTeammateIds: [marvin.id],
           openingMessage: ['Lets sync a bit later'],
           sentAt: validSentAt,
         }),
@@ -227,7 +227,7 @@ describe('ConversationsController', () => {
       await expect(
         controller.createDirectMessage(requestUser, {
           workspaceCode: koboMart.code,
-          recipientTeammateId: 999999,
+          recipientTeammateIds: [999999],
           openingMessage: ['Note to self'],
           sentAt: validSentAt,
         }),
@@ -248,7 +248,7 @@ describe('ConversationsController', () => {
 
       const directMessagePayload = {
         workspaceCode: koboMart.code,
-        recipientTeammateId: marvin.id,
+        recipientTeammateIds: [marvin.id],
         openingMessage: ['Hey, how are you feeling.'],
         sentAt: validSentAt,
       };
@@ -280,7 +280,7 @@ describe('ConversationsController', () => {
 
       const body = await controller.createDirectMessage(requestUser, {
         workspaceCode: koboMart.code,
-        recipientTeammateId: marvin.id,
+        recipientTeammateIds: [marvin.id],
         openingMessage: ['Hey there'],
         sentAt: validSentAt,
       });

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -120,17 +120,10 @@ export class ConversationsController {
       PERMISSIONS.MESSAGE_TEAMMATES,
       async (senderTeammate) => {
         try {
-          //TODO clean up only use recipientTeammateIds
-          const recipientTeammateIds: number[] = (
-            dto.recipientTeammateIds
-              ? dto.recipientTeammateIds
-              : [dto.recipientTeammateId]
-          ).filter((r) => r !== undefined);
-
           const conversation: Conversation =
             await this.teammatesService.runIfTeammatesInSameWorkspace(
               senderTeammate.id,
-              recipientTeammateIds,
+              dto.recipientTeammateIds,
               async (anchorTeammateId, teammateIds, workspaceCode) => {
                 // send text or open message
                 return await this.messenger.sendOpeningTextMessage(
@@ -147,7 +140,7 @@ export class ConversationsController {
             dto.workspaceCode,
             conversation.id,
             senderTeammate,
-            recipientTeammateIds,
+            dto.recipientTeammateIds,
             dto.openingMessage[0],
           );
 

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -6,7 +6,6 @@ import {
   IsDate,
   IsInt,
   IsNotEmpty,
-  IsOptional,
   IsString,
   MaxDate,
 } from 'class-validator';

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -42,7 +42,7 @@ export class CreateConversationDto {
   @ArrayNotEmpty()
   @Type(() => Number)
   @IsInt({ each: true })
-  recipientTeammateIds: number[]; //TODO: make this required
+  recipientTeammateIds: number[];
 
   @ApiProperty({
     type: String,

--- a/src/conversations/dto/create-conversation.dto.ts
+++ b/src/conversations/dto/create-conversation.dto.ts
@@ -19,11 +19,6 @@ export class CreateConversationDto {
   @IsNotEmpty()
   workspaceCode: string;
 
-  @ApiProperty({ description: 'Teammate ID of the recipient', example: 5 })
-  @IsInt()
-  @IsOptional()
-  recipientTeammateId?: number; // TODO take out this field
-
   @ApiProperty({
     description:
       'Messages to send when the conversation is created (max 2000 characters total)',
@@ -44,11 +39,10 @@ export class CreateConversationDto {
     minItems: 1,
     type: [Number],
   })
-  @IsOptional()
-  @IsArray()
+  @ArrayNotEmpty()
   @Type(() => Number)
   @IsInt({ each: true })
-  recipientTeammateIds?: number[]; //TODO: make this required
+  recipientTeammateIds: number[]; //TODO: make this required
 
   @ApiProperty({
     type: String,


### PR DESCRIPTION
To temporarily support the old way of creating conversations, we had to do this to support both old and new payloads. Now that we've fixed the frontend, we can clean this up. 