### PR TITLE
Add username to preverification

### DIFF
--- a/prisma/README.md
+++ b/prisma/README.md
@@ -14,3 +14,7 @@
 
 ### Generate client with command:
 1. `pnpx prisma generate`
+
+
+### Known issues:
+1. Adding a new column fails CI: The happen because fields in factory are not in sync fields in prisma ci. Go to the factory class of entity and update. 

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -17,4 +17,4 @@
 
 
 ### Known issues:
-1. Adding a new column fails CI: The happen because fields in factory are not in sync fields in prisma ci. Go to the factory class of entity and update. 
+1. Adding a new column fails CI: The happen because fields in factory are not in sync fields in prisma ci. Go to the factory class of entity and update. Example [PR](https://github.com/exwestafrican/wagz/pull/287)

--- a/prisma/migrations/20260801140231_add_username_to_preverification/migration.sql
+++ b/prisma/migrations/20260801140231_add_username_to_preverification/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PreVerification" ADD COLUMN     "username" VARCHAR(225);

--- a/prisma/schemas/preverification.prisma
+++ b/prisma/schemas/preverification.prisma
@@ -9,6 +9,7 @@ model PreVerification {
   firstName        String                @db.VarChar(100)
   lastName         String                @db.VarChar(100)
   companyName      String                @db.VarChar(225)
+  username         String?               @db.VarChar(225)
   phoneCountryCode String?               @db.VarChar(5) // e.g., "+1", "+44"
   phoneNumber      String?               @db.VarChar(15) // National number without country code
   status           PreVerificationStatus @default(PENDING)

--- a/src/factories/preverification.factory.ts
+++ b/src/factories/preverification.factory.ts
@@ -13,6 +13,7 @@ const preVerificationFactory = Factory.define<PreVerification>(() => {
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     companyName: faker.company.name(),
+    username: faker.internet.username(),
     phoneCountryCode: '+234',
     phoneNumber: '8169098834',
     status: PreVerificationStatus.PENDING,

--- a/src/factories/roadmap/preverification.factory.ts
+++ b/src/factories/roadmap/preverification.factory.ts
@@ -13,6 +13,7 @@ const preVerificationFactory = Factory.define<PreVerification>(() => {
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
     companyName: faker.company.name(),
+    username: faker.internet.username(),
     phoneCountryCode: '+234',
     phoneNumber: '8169098834',
     status: PreVerificationStatus.PENDING,


### PR DESCRIPTION
## Summary

https://github.com/exwestafrican/wagz/issues/286

We let customers set a username when they accept an invite, but not during workspace sign-up. 🤔 Got feedback that this wasn't a good user experience.  We will fix this by letting users submit a username during the pre-verification phase. 


🤦🏾‍♂️ I see we have two pre-verification factories; I'll clean that up. 