### PR TITLE
Add logic to check against normalized username and write normalized username when we create teammate

### DIFF
--- a/src/backfill/tasks/normalize-username.ts
+++ b/src/backfill/tasks/normalize-username.ts
@@ -2,6 +2,7 @@ import { Teammate, Workspace } from '@/generated/prisma/client';
 import BackfillTask from '@/backfill/task';
 import { PrismaService } from '@/prisma/prisma.service';
 import { Logger } from '@nestjs/common';
+import normalizeUsername from '@/common/normalize-username';
 
 export class NormalizeUsernames implements BackfillTask {
   logger = new Logger(NormalizeUsernames.name);
@@ -23,7 +24,7 @@ export class NormalizeUsernames implements BackfillTask {
         await this.prismaService.teammate.update({
           where: { id: teammate.id },
           data: {
-            normalizedUsername: this.normalizeUsername(teammate.username),
+            normalizedUsername: normalizeUsername(teammate.username),
           },
         });
         this.logger.log(
@@ -33,9 +34,5 @@ export class NormalizeUsernames implements BackfillTask {
         this.logger.warn(`Teammate has no username; id=${teammate.id}`);
       }
     }
-  }
-
-  private normalizeUsername(username: string) {
-    return username.split('.').join('');
   }
 }

--- a/src/common/normalize-username.ts
+++ b/src/common/normalize-username.ts
@@ -1,0 +1,3 @@
+export default function normalizeUsername(username: string): string {
+  return username.split('.').join('');
+}

--- a/src/factories/preverification.factory.ts
+++ b/src/factories/preverification.factory.ts
@@ -7,26 +7,28 @@ import { Factory } from 'fishery';
 import { PrismaService } from '@/prisma/prisma.service';
 import buildUsername from '@/common/build-username';
 
-const preVerificationFactory = Factory.define<PreVerification>(() => {
-  const firstName = faker.person.firstName();
-  const lastName = faker.person.lastName();
-  const username = buildUsername(firstName, lastName);
+const preVerificationFactory = Factory.define<PreVerification>(
+  ({ params }) => {
+    const firstName = params.firstName ?? faker.person.firstName();
+    const lastName = params.lastName ?? faker.person.lastName();
+    const username = params.username ?? buildUsername(firstName, lastName);
 
-  return {
-    id: faker.string.uuid(),
-    email: faker.internet.email(),
-    firstName: firstName,
-    lastName: lastName,
-    companyName: faker.company.name(),
-    username: username,
-    phoneCountryCode: '+234',
-    phoneNumber: '8169098834',
-    status: PreVerificationStatus.PENDING,
-    createdAt: faker.date.past(),
-    updatedAt: faker.date.recent(),
-    timezone: 'Africa/Lagos',
-  };
-});
+    return {
+      id: faker.string.uuid(),
+      email: faker.internet.email(),
+      firstName: firstName,
+      lastName: lastName,
+      companyName: faker.company.name(),
+      username: username,
+      phoneCountryCode: '+234',
+      phoneNumber: '8169098834',
+      status: PreVerificationStatus.PENDING,
+      createdAt: faker.date.past(),
+      updatedAt: faker.date.recent(),
+      timezone: 'Africa/Lagos',
+    };
+  },
+);
 
 export async function persistPreVerification(
   prismaService: PrismaService,

--- a/src/factories/preverification.factory.ts
+++ b/src/factories/preverification.factory.ts
@@ -7,28 +7,26 @@ import { Factory } from 'fishery';
 import { PrismaService } from '@/prisma/prisma.service';
 import buildUsername from '@/common/build-username';
 
-const preVerificationFactory = Factory.define<PreVerification>(
-  ({ params }) => {
-    const firstName = params.firstName ?? faker.person.firstName();
-    const lastName = params.lastName ?? faker.person.lastName();
-    const username = params.username ?? buildUsername(firstName, lastName);
+const preVerificationFactory = Factory.define<PreVerification>(({ params }) => {
+  const firstName = params.firstName ?? faker.person.firstName();
+  const lastName = params.lastName ?? faker.person.lastName();
+  const username = params.username ?? buildUsername(firstName, lastName);
 
-    return {
-      id: faker.string.uuid(),
-      email: faker.internet.email(),
-      firstName: firstName,
-      lastName: lastName,
-      companyName: faker.company.name(),
-      username: username,
-      phoneCountryCode: '+234',
-      phoneNumber: '8169098834',
-      status: PreVerificationStatus.PENDING,
-      createdAt: faker.date.past(),
-      updatedAt: faker.date.recent(),
-      timezone: 'Africa/Lagos',
-    };
-  },
-);
+  return {
+    id: faker.string.uuid(),
+    email: faker.internet.email(),
+    firstName: firstName,
+    lastName: lastName,
+    companyName: faker.company.name(),
+    username: username,
+    phoneCountryCode: '+234',
+    phoneNumber: '8169098834',
+    status: PreVerificationStatus.PENDING,
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.recent(),
+    timezone: 'Africa/Lagos',
+  };
+});
 
 export async function persistPreVerification(
   prismaService: PrismaService,

--- a/src/factories/roadmap/preverification.factory.ts
+++ b/src/factories/roadmap/preverification.factory.ts
@@ -7,25 +7,27 @@ import { faker } from '@faker-js/faker';
 import { PrismaService } from '@/prisma/prisma.service';
 import buildUsername from '@/common/build-username';
 
-const preVerificationFactory = Factory.define<PreVerification>(() => {
-  const firstName = faker.person.firstName();
-  const lastName = faker.person.lastName();
-  const username = buildUsername(firstName, lastName);
-  return {
-    id: faker.string.uuid(),
-    email: faker.internet.email(),
-    firstName: firstName,
-    lastName: lastName,
-    companyName: faker.company.name(),
-    username: username,
-    phoneCountryCode: '+234',
-    phoneNumber: '8169098834',
-    status: PreVerificationStatus.PENDING,
-    createdAt: faker.date.past(),
-    updatedAt: faker.date.recent(),
-    timezone: 'Africa/Lagos',
-  };
-});
+const preVerificationFactory = Factory.define<PreVerification>(
+  ({ params }) => {
+    const firstName = params.firstName ?? faker.person.firstName();
+    const lastName = params.lastName ?? faker.person.lastName();
+    const username = params.username ?? buildUsername(firstName, lastName);
+    return {
+      id: faker.string.uuid(),
+      email: faker.internet.email(),
+      firstName: firstName,
+      lastName: lastName,
+      companyName: faker.company.name(),
+      username: username,
+      phoneCountryCode: '+234',
+      phoneNumber: '8169098834',
+      status: PreVerificationStatus.PENDING,
+      createdAt: faker.date.past(),
+      updatedAt: faker.date.recent(),
+      timezone: 'Africa/Lagos',
+    };
+  },
+);
 
 export async function persistPreverificationStrategy(
   prismaService: PrismaService,

--- a/src/factories/roadmap/preverification.factory.ts
+++ b/src/factories/roadmap/preverification.factory.ts
@@ -7,27 +7,25 @@ import { faker } from '@faker-js/faker';
 import { PrismaService } from '@/prisma/prisma.service';
 import buildUsername from '@/common/build-username';
 
-const preVerificationFactory = Factory.define<PreVerification>(
-  ({ params }) => {
-    const firstName = params.firstName ?? faker.person.firstName();
-    const lastName = params.lastName ?? faker.person.lastName();
-    const username = params.username ?? buildUsername(firstName, lastName);
-    return {
-      id: faker.string.uuid(),
-      email: faker.internet.email(),
-      firstName: firstName,
-      lastName: lastName,
-      companyName: faker.company.name(),
-      username: username,
-      phoneCountryCode: '+234',
-      phoneNumber: '8169098834',
-      status: PreVerificationStatus.PENDING,
-      createdAt: faker.date.past(),
-      updatedAt: faker.date.recent(),
-      timezone: 'Africa/Lagos',
-    };
-  },
-);
+const preVerificationFactory = Factory.define<PreVerification>(({ params }) => {
+  const firstName = params.firstName ?? faker.person.firstName();
+  const lastName = params.lastName ?? faker.person.lastName();
+  const username = params.username ?? buildUsername(firstName, lastName);
+  return {
+    id: faker.string.uuid(),
+    email: faker.internet.email(),
+    firstName: firstName,
+    lastName: lastName,
+    companyName: faker.company.name(),
+    username: username,
+    phoneCountryCode: '+234',
+    phoneNumber: '8169098834',
+    status: PreVerificationStatus.PENDING,
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.recent(),
+    timezone: 'Africa/Lagos',
+  };
+});
 
 export async function persistPreverificationStrategy(
   prismaService: PrismaService,

--- a/src/factories/teammate.factory.ts
+++ b/src/factories/teammate.factory.ts
@@ -4,23 +4,25 @@ import { faker } from '@faker-js/faker';
 import { ROLES } from '@/permission/types';
 import { PrismaService } from '@/prisma/prisma.service';
 import { sixCharHumanFriendlyCode } from '@/factories/code-generator';
+import normalizeUsername from '@/common/normalize-username';
 
 class TeammateFactory extends Factory<Teammate> {
   adminTeammate() {
     return this.build({ groups: [ROLES.WorkspaceAdmin.code] });
   }
 }
-const teammateFactory = TeammateFactory.define(({ sequence }) => {
-  const firstName = faker.person.firstName();
-  const lastName = faker.person.lastName();
-  const username = `${firstName}.${lastName}`;
+const teammateFactory = TeammateFactory.define(({ sequence, params }) => {
+  const firstName = params.firstName ?? faker.person.firstName();
+  const lastName = params.lastName ?? faker.person.lastName();
+  const username = params.username ?? `${firstName}.${lastName}`;
   return {
     id: sequence,
     email: faker.internet.email(),
     firstName: firstName,
     lastName: lastName,
     username: username,
-    normalizedUsername: username.split('.').join(''),
+    normalizedUsername:
+      params.normalizedUsername ?? normalizeUsername(username),
     workspaceCode: sixCharHumanFriendlyCode(),
     status: TeammateStatus.ACTIVE,
     avatarUrl: faker.internet.url(),

--- a/src/teammates/teammates.controller.spec.ts
+++ b/src/teammates/teammates.controller.spec.ts
@@ -169,6 +169,22 @@ describe('TeammatesController', () => {
         .expect(HttpStatus.CONFLICT);
     });
 
+    it('should return 409 when the normalized form of the username is already taken', async () => {
+      const { workspace } = await setupWorkspaceWithTeammate(
+        factory,
+        teammateFactory.build({
+          email: requestUser.email,
+          username: 'laura.smith',
+        }),
+      );
+
+      await request(getHttpServer(app))
+        .get(TeammatesEndpoints.CHECK_USERNAME)
+        .query({ workspaceCode: workspace.code, username: 'laurasmith' })
+        .set('Accept', 'application/json')
+        .expect(HttpStatus.CONFLICT);
+    });
+
     test.each([
       ['90-...jky', 'starts with digit and has consecutive separators'],
       ['laura smith', 'contains a space'],

--- a/src/teammates/teammates.service.spec.ts
+++ b/src/teammates/teammates.service.spec.ts
@@ -177,7 +177,11 @@ describe('TeammatesService', () => {
         await setupWorkspaceWithMultipleTeammates(factory, 1);
       await prismaService.teammate.update({
         where: { id: teammates[0].id },
-        data: { email: requestUser.email, username: 'laura.smith' },
+        data: {
+          email: requestUser.email,
+          username: 'laura.smith',
+          normalizedUsername: 'laurasmith',
+        },
       });
 
       const usernameTaken = await service.usernameAlreadyExistsInWorkspace(
@@ -188,12 +192,36 @@ describe('TeammatesService', () => {
       expect(usernameTaken).toBe(true);
     });
 
+    it('should return true when the normalized form of the username is already taken', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 1);
+      await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          username: 'laura.smith',
+          normalizedUsername: 'laurasmith',
+        },
+      });
+
+      const usernameTaken = await service.usernameAlreadyExistsInWorkspace(
+        koboMart.code,
+        'laurasmith',
+      );
+
+      expect(usernameTaken).toBe(true);
+    });
+
     it('should return false when no teammate with that username exists in the workspace', async () => {
       const { workspace: koboMart, teammates } =
         await setupWorkspaceWithMultipleTeammates(factory, 1);
       await prismaService.teammate.update({
         where: { id: teammates[0].id },
-        data: { email: requestUser.email, username: 'laura.smith' },
+        data: {
+          email: requestUser.email,
+          username: 'laura.smith',
+          normalizedUsername: 'laurasmith',
+        },
       });
 
       const usernameTaken = await service.usernameAlreadyExistsInWorkspace(

--- a/src/teammates/teammates.service.ts
+++ b/src/teammates/teammates.service.ts
@@ -4,6 +4,7 @@ import { TeammateStatus } from '@/generated/prisma/enums';
 import { Teammate } from '@/generated/prisma/client';
 import { TeammatesNotInSameWorkspace } from '@/common/exceptions/teammates-not-in-same-workspace';
 import NotFoundInDb from '@/common/exceptions/not-found';
+import normalizeUsername from '@/common/normalize-username';
 
 @Injectable()
 export class TeammatesService {
@@ -54,9 +55,9 @@ export class TeammatesService {
   ) {
     const exists = await this.prismaService.teammate.findUnique({
       where: {
-        workspaceCode_username: {
+        workspaceCode_normalizedUsername: {
           workspaceCode,
-          username,
+          normalizedUsername: normalizeUsername(username),
         },
       },
       select: { id: true },

--- a/src/teammates/teammates.service.ts
+++ b/src/teammates/teammates.service.ts
@@ -53,12 +53,10 @@ export class TeammatesService {
     workspaceCode: string,
     username: string,
   ) {
-    const exists = await this.prismaService.teammate.findUnique({
+    const exists = await this.prismaService.teammate.findFirst({
       where: {
-        workspaceCode_normalizedUsername: {
-          workspaceCode,
-          normalizedUsername: normalizeUsername(username),
-        },
+        workspaceCode,
+        normalizedUsername: normalizeUsername(username),
       },
       select: { id: true },
     });

--- a/src/workspace/steps/create-super-admin.ts
+++ b/src/workspace/steps/create-super-admin.ts
@@ -3,26 +3,26 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { WorkspaceDetails } from '@/workspace/domain/workspace-details';
 import { PostSetupStep } from '@/workspace/steps/postsetup-step';
 import { ROLES } from '@/permission/types';
-import { PointOfContact } from '../domain/point-of-contact';
+import buildUsername from '@/common/build-username';
+import normalizeUsername from '@/common/normalize-username';
 
 export class CreateSuperAdminStep implements PostSetupStep {
   logger = new Logger(CreateSuperAdminStep.name);
   constructor(private readonly prismaService: PrismaService) {}
 
-  private username(pointOfContact: PointOfContact) {
-    return [pointOfContact.firstName, pointOfContact.lastName]
-      .map((name) => name.toLowerCase())
-      .join('.');
-  }
-
   async execute(workspaceDetails: WorkspaceDetails): Promise<void> {
     const pointOfContact = workspaceDetails.pointOfContact;
+    const username = buildUsername(
+      pointOfContact.firstName,
+      pointOfContact.lastName,
+    );
     await this.prismaService.teammate.create({
       data: {
         email: pointOfContact.email,
         firstName: pointOfContact.firstName,
         lastName: pointOfContact.lastName,
-        username: this.username(pointOfContact),
+        username,
+        normalizedUsername: normalizeUsername(username),
         workspaceCode: workspaceDetails.code,
         groups: [ROLES.SuperAdmin.code],
       },

--- a/src/workspace/steps/create-workspace-admin.spec.ts
+++ b/src/workspace/steps/create-workspace-admin.spec.ts
@@ -76,6 +76,9 @@ describe('CreateWorkspaceAdminStep', () => {
     expect(createdTeammate.username).toBe(
       `${workspaceDetails.pointOfContact.firstName.toLowerCase()}.${workspaceDetails.pointOfContact.lastName.toLowerCase()}`,
     );
+    expect(createdTeammate.normalizedUsername).toBe(
+      `${workspaceDetails.pointOfContact.firstName.toLowerCase()}${workspaceDetails.pointOfContact.lastName.toLowerCase()}`,
+    );
 
     await step.compensate(workspaceDetails);
 

--- a/src/workspace/steps/create-workspace-admin.ts
+++ b/src/workspace/steps/create-workspace-admin.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { WorkspaceDetails } from '@/workspace/domain/workspace-details';
 import { PostSetupStep } from '@/workspace/steps/postsetup-step';
 import { ROLES } from '@/permission/types';
+import normalizeUsername from '@/common/normalize-username';
 
 export class CreateWorkspaceAdminStep implements PostSetupStep {
   logger = new Logger(CreateWorkspaceAdminStep.name);
@@ -16,6 +17,7 @@ export class CreateWorkspaceAdminStep implements PostSetupStep {
         firstName: pointOfContact.firstName,
         lastName: pointOfContact.lastName,
         username: pointOfContact.username,
+        normalizedUsername: normalizeUsername(pointOfContact.username),
         workspaceCode: workspaceDetails.code,
         groups: [ROLES.WorkspaceAdmin.code],
       },

--- a/src/workspace/workspace-invite-service.spec.ts
+++ b/src/workspace/workspace-invite-service.spec.ts
@@ -213,6 +213,7 @@ describe('WorkspaceInviteService', () => {
       });
       expect(createdTeammate.groups).toEqual([ROLES.SupportStaff.code]);
       expect(createdTeammate.username).toBe('laura.smith');
+      expect(createdTeammate.normalizedUsername).toBe('laurasmith');
 
       const invite = await prismaService.workspaceInvite.findFirstOrThrow({
         where: {

--- a/src/workspace/workspace-invite-service.ts
+++ b/src/workspace/workspace-invite-service.ts
@@ -14,6 +14,7 @@ import { render } from '@react-email/render';
 import { EMAIL_CLIENT, type EmailClient } from '@/messaging/email/email-client';
 import { fullName } from '@/teammates/utils/full-name';
 import FeatureFlagManager from '@/feature-flag/manager';
+import normalizeUsername from '@/common/normalize-username';
 
 export interface TeammateDetails {
   firstName: string;
@@ -119,6 +120,7 @@ export class WorkspaceInviteService {
           firstName: teammateDetails.firstName,
           lastName: teammateDetails.lastName,
           username: teammateDetails.username,
+          normalizedUsername: normalizeUsername(teammateDetails.username),
           groups: [invite.recipientRole],
         },
       });

--- a/src/workspace/workspace.controller.spec.ts
+++ b/src/workspace/workspace.controller.spec.ts
@@ -437,10 +437,11 @@ describe('WorkspaceController', () => {
 
       const createdTeammate = await prismaService.teammate.findFirstOrThrow({
         where: { workspaceCode: '9Jk076', email: 'laura@useenvoye.co' },
-        select: { groups: true, username: true },
+        select: { groups: true, username: true, normalizedUsername: true },
       });
       expect(createdTeammate.groups).toEqual([ROLES.SupportStaff.code]);
       expect(createdTeammate.username).toBe('laura.smith');
+      expect(createdTeammate.normalizedUsername).toBe('laurasmith');
 
       const invite = await prismaService.workspaceInvite.findFirstOrThrow({
         where: {


### PR DESCRIPTION
## Summary

Before backfilling the username. We need to forward-fix this so that new users get normalised usernames fixed. 