### PR TITLE
Allow Endpoint check for only username pattern where necessary

### DIFF
--- a/src/teammates/dto/check-username-query.dto.ts
+++ b/src/teammates/dto/check-username-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import {
   IsValidUsername,
   USERNAME_MAX_LENGTH,
@@ -20,6 +20,6 @@ export class CheckUsernameQueryDto {
 
   @ApiProperty({ description: 'Workspace code', example: '9Jk076' })
   @IsString()
-  @IsNotEmpty()
-  workspaceCode: string;
+  @IsOptional()
+  workspaceCode?: string;
 }

--- a/src/teammates/dto/check-username-query.dto.ts
+++ b/src/teammates/dto/check-username-query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 import {
   IsValidUsername,
   USERNAME_MAX_LENGTH,

--- a/src/teammates/teammates.controller.spec.ts
+++ b/src/teammates/teammates.controller.spec.ts
@@ -185,7 +185,7 @@ describe('TeammatesController', () => {
         .expect(HttpStatus.CONFLICT);
     });
 
-    test.each([
+    const INVALID_NAMES = [
       ['90-...jky', 'starts with digit and has consecutive separators'],
       ['laura smith', 'contains a space'],
       ['laura@smith', 'contains @'],
@@ -196,12 +196,25 @@ describe('TeammatesController', () => {
       ['_laura', 'has a leading separator'],
       ['laura!', 'has a disallowed special character'],
       ['a', 'is shorter than the minimum length'],
-    ])(
+    ];
+
+    test.each(INVALID_NAMES)(
       'should return 400 when the username %s is invalid (%s)',
       async (username: string) => {
         await request(getHttpServer(app))
           .get(TeammatesEndpoints.CHECK_USERNAME)
           .query({ workspaceCode: 'a1b2c3', username })
+          .set('Accept', 'application/json')
+          .expect(HttpStatus.BAD_REQUEST);
+      },
+    );
+
+    test.each(INVALID_NAMES)(
+      'should return 400 when the username %s is invalid (%s) and workspace is null',
+      async (username: string) => {
+        await request(getHttpServer(app))
+          .get(TeammatesEndpoints.CHECK_USERNAME)
+          .query({ username })
           .set('Accept', 'application/json')
           .expect(HttpStatus.BAD_REQUEST);
       },

--- a/src/teammates/teammates.controller.ts
+++ b/src/teammates/teammates.controller.ts
@@ -116,7 +116,7 @@ export class TeammatesController {
     status: HttpStatus.CONFLICT,
     description: 'Username is already taken in this workspace',
   })
-  async checkIfUsernameExists(
+  async checkIfUsernameIsValid(
     @Query() query: CheckUsernameQueryDto,
   ): Promise<void> {
     // means user just wants to check the pattern

--- a/src/teammates/teammates.controller.ts
+++ b/src/teammates/teammates.controller.ts
@@ -119,6 +119,8 @@ export class TeammatesController {
   async checkIfUsernameExists(
     @Query() query: CheckUsernameQueryDto,
   ): Promise<void> {
+    // means user just wants to check the pattern
+    if (!query.workspaceCode) return;
     const exists = await this.teammatesService.usernameAlreadyExistsInWorkspace(
       query.workspaceCode,
       query.username,


### PR DESCRIPTION
## Summary
A username is valid if it matches our regex pattern and is unique per workspace. 
However, for a new workspace, we know that it's the only username of its kind, so we only need to enforce the username pattern. This PR makes the workspace optional. So we only do pattern checks.