### PR TITLE
Add backfill task to link preverification to company profile

### DIFF
--- a/src/backfill/backfill-registry.provider.ts
+++ b/src/backfill/backfill-registry.provider.ts
@@ -1,6 +1,7 @@
 import { createTaskRegistry } from '@/backfill/task';
 import { NormalizeUsernames } from '@/backfill/tasks/normalize-username';
 import { ConversationParticipantsSignature } from '@/backfill/tasks/participants-signature';
+import { BackfillCompanyProfilePreverification } from '@/backfill/tasks/company-profile-preverification';
 import { PrismaService } from '@/prisma/prisma.service';
 import { ConversationsService } from '@/conversations/conversations.service';
 import { PrismaModule } from '@/prisma/prisma.module';
@@ -37,6 +38,14 @@ export const BackfillRegistryProvider = {
         ConversationsService,
       ),
       dateAdded: 1783166035, // 4th july 2026
+    });
+    registry.register({
+      name: 'Backfill Company Profile Preverification',
+      description:
+        'Links company profiles to PreVerification using email and company name',
+      key: 'company_profile_preverification',
+      task: new BackfillCompanyProfilePreverification(prismaService),
+      dateAdded: 1785671635, // 2nd august 2026
     });
     return registry;
   },

--- a/src/backfill/backfill.controller.spec.ts
+++ b/src/backfill/backfill.controller.spec.ts
@@ -75,7 +75,7 @@ describe('BackfillController', () => {
         .send()
         .expect(HttpStatus.OK);
       const body = response.body as BackfillResponseDto[];
-      expect(body.length).toBe(2);
+      expect(body.length).toBe(3);
     });
 
     it('should return 403 for when user is not super admin', async () => {

--- a/src/backfill/backfill.module.ts
+++ b/src/backfill/backfill.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '@/prisma/prisma.module';
 import { NormalizeUsernames } from '@/backfill/tasks/normalize-username';
+import { BackfillCompanyProfilePreverification } from '@/backfill/tasks/company-profile-preverification';
 import { BackfillController } from './backfill.controller';
 import { BackfillRegistryProvider } from '@/backfill/backfill-registry.provider';
 import { PermissionModule } from '@/permission/permission.module';
@@ -14,7 +15,11 @@ import { ConversationsModule } from '@/conversations/conversations.module';
     TeammatesModule,
     ConversationsModule,
   ],
-  providers: [NormalizeUsernames, BackfillRegistryProvider],
+  providers: [
+    NormalizeUsernames,
+    BackfillCompanyProfilePreverification,
+    BackfillRegistryProvider,
+  ],
   controllers: [BackfillController],
 })
 export class BackfillModule {}

--- a/src/backfill/tasks/company-profile-preverification.spec.ts
+++ b/src/backfill/tasks/company-profile-preverification.spec.ts
@@ -1,0 +1,168 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { createTestApp } from '@/test-helpers/test-app';
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '@/prisma/prisma.service';
+import Factory, { PersistStrategy } from '@/factories/factory';
+import { setupWorkspaceWithTeammate } from '@/test-helpers/workspace-helpers';
+import teammateFactory from '@/factories/teammate.factory';
+import preVerificationFactory from '@/factories/preverification.factory';
+import { ROLES } from '@/permission/types';
+import { BackfillCompanyProfilePreverification } from '@/backfill/tasks/company-profile-preverification';
+import { resetDb } from '@/test-helpers/rest-db';
+import { Workspace } from '@/generated/prisma/client';
+
+describe('Backfill Company Profile Preverification Task', () => {
+  let app: INestApplication;
+  let prismaService: PrismaService;
+  let factory: PersistStrategy;
+  let service: BackfillCompanyProfilePreverification;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot(), PrismaModule],
+      providers: [],
+    }).compile();
+
+    app = await createTestApp(module);
+    prismaService = app.get<PrismaService>(PrismaService);
+    factory = Factory.createStrategy(prismaService);
+    service = new BackfillCompanyProfilePreverification(prismaService);
+  });
+
+  afterEach(async () => {
+    await resetDb(prismaService);
+    await app.close();
+  });
+
+  async function companyProfileFor(workspace: Workspace) {
+    return prismaService.companyProfile.findUniqueOrThrow({
+      where: { id: workspace.ownedById },
+    });
+  }
+
+  async function setupWorkspace() {
+    return setupWorkspaceWithTeammate(
+      factory,
+      teammateFactory.build({
+        username: 'tumise',
+        normalizedUsername: 'tumise',
+        email: 'tumise@example.com',
+        groups: [ROLES.WorkspaceAdmin.code],
+      }),
+    );
+  }
+
+  test('links company profile when email and company name match', async () => {
+    const { workspace } = await setupWorkspace();
+    const companyProfile = await companyProfileFor(workspace);
+
+    const matchingPreVerification = await factory.persist(
+      'preverification',
+      () =>
+        preVerificationFactory.build({
+          email: 'poc@example.com',
+          companyName: 'Kobo Mart',
+        }),
+    );
+
+    await prismaService.companyProfile.update({
+      where: { id: companyProfile.id },
+      data: {
+        pointOfContactEmail: 'poc@example.com',
+        companyName: 'Kobo Mart',
+        preVerificationId: null,
+      },
+    });
+
+    await service.run(workspace);
+
+    const updatedCompanyProfile = await companyProfileFor(workspace);
+    expect(updatedCompanyProfile.preVerificationId).toBe(
+      matchingPreVerification.id,
+    );
+  });
+
+  test('resets preVerificationId when already linked to a different record', async () => {
+    const { workspace } = await setupWorkspace();
+    const companyProfile = await companyProfileFor(workspace);
+    const previousPreVerificationId = companyProfile.preVerificationId;
+
+    const matchingPreVerification = await factory.persist(
+      'preverification',
+      () =>
+        preVerificationFactory.build({
+          email: 'poc@example.com',
+          companyName: 'Kobo Mart',
+        }),
+    );
+
+    await prismaService.companyProfile.update({
+      where: { id: companyProfile.id },
+      data: {
+        pointOfContactEmail: 'poc@example.com',
+        companyName: 'Kobo Mart',
+      },
+    });
+
+    await service.run(workspace);
+
+    const updatedCompanyProfile = await companyProfileFor(workspace);
+    expect(updatedCompanyProfile.preVerificationId).toBe(
+      matchingPreVerification.id,
+    );
+    expect(updatedCompanyProfile.preVerificationId).not.toBe(
+      previousPreVerificationId,
+    );
+  });
+
+  test('leaves preVerificationId unchanged when company name does not match', async () => {
+    const { workspace } = await setupWorkspace();
+    const companyProfile = await companyProfileFor(workspace);
+    const originalPreVerificationId = companyProfile.preVerificationId;
+
+    await factory.persist('preverification', () =>
+      preVerificationFactory.build({
+        email: 'poc@example.com',
+        companyName: 'Kobo Mart',
+      }),
+    );
+
+    await prismaService.companyProfile.update({
+      where: { id: companyProfile.id },
+      data: {
+        pointOfContactEmail: 'poc@example.com',
+        companyName: 'Zuri Bakery',
+      },
+    });
+
+    await service.run(workspace);
+
+    const unchangedCompanyProfile = await companyProfileFor(workspace);
+    expect(unchangedCompanyProfile.preVerificationId).toBe(
+      originalPreVerificationId,
+    );
+  });
+
+  test('leaves preVerificationId unchanged when no preverification matches', async () => {
+    const { workspace } = await setupWorkspace();
+    const companyProfile = await companyProfileFor(workspace);
+    const originalPreVerificationId = companyProfile.preVerificationId;
+
+    await prismaService.companyProfile.update({
+      where: { id: companyProfile.id },
+      data: {
+        pointOfContactEmail: 'unmatched@example.com',
+        companyName: 'Unknown Co',
+      },
+    });
+
+    await service.run(workspace);
+
+    const unchangedCompanyProfile = await companyProfileFor(workspace);
+    expect(unchangedCompanyProfile.preVerificationId).toBe(
+      originalPreVerificationId,
+    );
+  });
+});

--- a/src/backfill/tasks/company-profile-preverification.ts
+++ b/src/backfill/tasks/company-profile-preverification.ts
@@ -1,0 +1,42 @@
+import BackfillTask from '@/backfill/task';
+import { PrismaService } from '@/prisma/prisma.service';
+import { Logger } from '@nestjs/common';
+import { Workspace } from '@/generated/prisma/client';
+
+export class BackfillCompanyProfilePreverification implements BackfillTask {
+  logger = new Logger(BackfillCompanyProfilePreverification.name);
+
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async run(workspace: Workspace): Promise<void> {
+    const workspaceWithOwner =
+      await this.prismaService.workspace.findUniqueOrThrow({
+        where: { id: workspace.id },
+        include: { ownedBy: true },
+      });
+    const companyProfile = workspaceWithOwner.ownedBy;
+
+    const preVerification = await this.prismaService.preVerification.findFirst({
+      where: {
+        email: companyProfile.pointOfContactEmail,
+        companyName: companyProfile.companyName,
+      },
+    });
+
+    if (!preVerification) {
+      this.logger.warn(
+        `No preverification matching email and company name; companyProfileId=${companyProfile.id} email=${companyProfile.pointOfContactEmail} companyName=${companyProfile.companyName}`,
+      );
+      return;
+    }
+
+    await this.prismaService.companyProfile.update({
+      where: { id: companyProfile.id },
+      data: { preVerificationId: preVerification.id },
+    });
+
+    this.logger.log(
+      `Linked company profile to preverification; companyProfileId=${companyProfile.id} preVerificationId=${preVerification.id}`,
+    );
+  }
+}


### PR DESCRIPTION
Towards https://github.com/exwestafrican/wagz/issues/155 . 🤔 We now write preverification for new records. Lets add a bacfill task to fix old ones. 


<img width="637" height="484" alt="Screenshot 2026-08-02 at 10 41 24" src="https://github.com/user-attachments/assets/9780e953-ca67-42d3-94d2-fca64b4a9e86" />
