### PR TITLE
Allow Clients Fetch their own Skipped Messages

### DIFF
--- a/src/conversations/conversations.controller.spec.ts
+++ b/src/conversations/conversations.controller.spec.ts
@@ -27,6 +27,7 @@ import { resetDb } from '@/test-helpers/rest-db';
 import { ROLES } from '@/permission/types';
 import { CreateConversationDto } from '@/conversations/dto/create-conversation.dto';
 import { SendTextMessageDto } from '@/conversations/dto/send-message.dto';
+import { MessagesSinceQueryDto } from '@/conversations/dto/messages-since-query.dto';
 import { TestEmailClient } from '@/messaging/email/test-email-client';
 import { LinkService } from '@/common/link-service';
 import { mockConfigService } from '@/test-helpers/mocks';
@@ -874,7 +875,232 @@ describe('ConversationsController', () => {
     });
   });
 
+  describe('messagesSince', () => {
+    const openingSentAt = new Date('2026-06-20T10:00:00.000Z');
+    const replySentAt = new Date('2026-06-20T10:01:00.000Z');
+    const followUpSentAt = new Date('2026-06-20T10:02:00.000Z');
+
+    it('returns messages since lastReadMessageId without advancing the DB cursor', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+
+      const dan = await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [ROLES.WorkspaceMember.code],
+        },
+      });
+      const marvin = teammates[1];
+
+      const conversation = await envoyeMessenger.sendOpeningTextMessage(
+        dan.id,
+        [marvin.id],
+        koboMart.code,
+        ['First message'],
+        openingSentAt,
+      );
+
+      await envoyeMessenger.sendTextMessage(
+        conversation.id,
+        marvin.id,
+        ['Second message'],
+        replySentAt,
+      );
+
+      await envoyeMessenger.sendTextMessage(
+        conversation.id,
+        dan.id,
+        ['Third message'],
+        followUpSentAt,
+      );
+
+      const messages = await prismaService.message.findMany({
+        where: { conversationId: conversation.id },
+        orderBy: { sentAt: 'asc' },
+      });
+
+      const messagesSince = await controller.messagesSince(requestUser, {
+        workspaceCode: koboMart.code,
+        conversationId: conversation.id,
+        lastReadMessageId: messages[0].id,
+      });
+
+      expect(messagesSince).toHaveLength(2);
+      expect(messagesSince.map((message) => message.content)).toEqual([
+        ['Second message'],
+        ['Third message'],
+      ]);
+
+      const participantInfo =
+        await prismaService.conversationParticipant.findFirstOrThrow({
+          where: { teammateId: dan.id, conversationId: conversation.id },
+        });
+      expect(participantInfo.lastReadMessage).toBeNull();
+    });
+
+    it('returns an empty list when there are no messages after the cursor', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+
+      const dan = await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [ROLES.WorkspaceMember.code],
+        },
+      });
+      const marvin = teammates[1];
+
+      const conversation = await envoyeMessenger.sendOpeningTextMessage(
+        dan.id,
+        [marvin.id],
+        koboMart.code,
+        ['Hey Marvin'],
+        openingSentAt,
+      );
+
+      const messages = await prismaService.message.findMany({
+        where: { conversationId: conversation.id },
+        orderBy: { sentAt: 'asc' },
+      });
+
+      const messagesSince = await controller.messagesSince(requestUser, {
+        workspaceCode: koboMart.code,
+        conversationId: conversation.id,
+        lastReadMessageId: messages[0].id,
+      });
+
+      expect(messagesSince).toEqual([]);
+    });
+
+    it('returns the same messages for repeated calls with the same cursor', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+
+      const dan = await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [ROLES.WorkspaceMember.code],
+        },
+      });
+      const marvin = teammates[1];
+
+      const conversation = await envoyeMessenger.sendOpeningTextMessage(
+        dan.id,
+        [marvin.id],
+        koboMart.code,
+        ['First message'],
+        openingSentAt,
+      );
+
+      await envoyeMessenger.sendTextMessage(
+        conversation.id,
+        marvin.id,
+        ['Second message'],
+        replySentAt,
+      );
+
+      const messages = await prismaService.message.findMany({
+        where: { conversationId: conversation.id },
+        orderBy: { sentAt: 'asc' },
+      });
+
+      const firstFetch = await controller.messagesSince(requestUser, {
+        workspaceCode: koboMart.code,
+        conversationId: conversation.id,
+        lastReadMessageId: messages[0].id,
+      });
+      const secondFetch = await controller.messagesSince(requestUser, {
+        workspaceCode: koboMart.code,
+        conversationId: conversation.id,
+        lastReadMessageId: messages[0].id,
+      });
+
+      expect(firstFetch.map((message) => message.id)).toEqual([messages[1].id]);
+      expect(secondFetch.map((message) => message.id)).toEqual(
+        firstFetch.map((message) => message.id),
+      );
+    });
+
+    it('throws NotFoundException when requester is not a participant', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 3);
+
+      await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [ROLES.WorkspaceMember.code],
+        },
+      });
+
+      const dan = teammates[1];
+      const marvin = teammates[2];
+
+      const conversation = await envoyeMessenger.sendOpeningTextMessage(
+        dan.id,
+        [marvin.id],
+        koboMart.code,
+        ['Hey Marvin'],
+        openingSentAt,
+      );
+
+      await expect(
+        controller.messagesSince(requestUser, {
+          workspaceCode: koboMart.code,
+          conversationId: conversation.id,
+          lastReadMessageId: 1,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when requester lacks message_teammates permission', async () => {
+      const { workspace: koboMart, teammates } =
+        await setupWorkspaceWithMultipleTeammates(factory, 2);
+
+      const dan = await prismaService.teammate.update({
+        where: { id: teammates[0].id },
+        data: {
+          email: requestUser.email,
+          groups: [],
+        },
+      });
+      const marvin = teammates[1];
+
+      const conversation = await envoyeMessenger.sendOpeningTextMessage(
+        dan.id,
+        [marvin.id],
+        koboMart.code,
+        ['Hey Marvin'],
+        openingSentAt,
+      );
+
+      await expect(
+        controller.messagesSince(requestUser, {
+          workspaceCode: koboMart.code,
+          conversationId: conversation.id,
+          lastReadMessageId: 1,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
   describe('sentAt validation', () => {
+    it('rejects MessagesSinceQueryDto when lastReadMessageId is omitted', async () => {
+      const dto = plainToInstance(MessagesSinceQueryDto, {
+        workspaceCode: '12er56',
+        conversationId: 1,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.map((error) => error.property)).toContain(
+        'lastReadMessageId',
+      );
+    });
+
     it('rejects SendTextMessageDto when sentAt is omitted', async () => {
       const dto = plainToInstance(SendTextMessageDto, {
         workspaceCode: '12er56',

--- a/src/conversations/conversations.controller.ts
+++ b/src/conversations/conversations.controller.ts
@@ -40,6 +40,7 @@ import {
 } from '@/conversations/dto/chat-history.dto';
 import { isSame } from '@/common/utils';
 import { UnreadMessageQueryDto } from '@/conversations/dto/unread-message-query.dto';
+import { MessagesSinceQueryDto } from '@/conversations/dto/messages-since-query.dto';
 import { ConversationType } from '@/conversations/const';
 
 @Controller('conversations')
@@ -285,10 +286,60 @@ export class ConversationsController {
     return history.map((msg) => toChatHistoryDto(msg));
   }
 
+  @Get('messages-since')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Fetch messages since a client-owned cursor',
+    description:
+      'Returns up to 100 messages with id greater than lastReadMessageId, ordered oldest to newest. ' +
+      'Does not mark messages as read. Each client should track its own lastReadMessageId. ' +
+      'Bootstrap via chat-history first, then poll with the max message id.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Messages since the cursor in chronological order',
+    type: ChatHistoryDto,
+    isArray: true,
+  })
+  @ApiBadRequestResponse()
+  @ApiForbiddenResponse()
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Conversation not found or requester is not a participant',
+  })
+  @UseGuards(SupabaseAuthGuard)
+  async messagesSince(
+    @User() requestUser: RequestUser,
+    @Query() query: MessagesSinceQueryDto,
+  ): Promise<ChatHistoryDto[]> {
+    const messagesSinceCursor =
+      await this.permissionService.runIfActiveWorkspaceMemberAndPermitted(
+        requestUser,
+        query.workspaceCode,
+        PERMISSIONS.MESSAGE_TEAMMATES,
+        async (requestTeammate) => {
+          return this.conversationsService.runIfConversationParticipant(
+            query.conversationId,
+            requestTeammate.id,
+            async () =>
+              await this.messenger.loadMessagesSince(
+                query.conversationId,
+                query.lastReadMessageId,
+              ),
+          );
+        },
+      );
+    return messagesSinceCursor.map((msg) => toChatHistoryDto(msg));
+  }
+
   @Get('unread-messages')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Fetch all unread messages for teammate for a given conversation',
+    deprecated: true,
+    description:
+      'Deprecated: use GET /conversations/messages-since with a client-owned lastReadMessageId instead. ' +
+      'This endpoint advances a shared server-side read cursor and is not safe for multi-client use.',
   })
   @ApiBadRequestResponse()
   @ApiForbiddenResponse()

--- a/src/conversations/dto/messages-since-query.dto.ts
+++ b/src/conversations/dto/messages-since-query.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class MessagesSinceQueryDto {
+  @ApiProperty({ description: 'Workspace code', example: '12er56' })
+  @IsString()
+  @IsNotEmpty()
+  workspaceCode: string;
+
+  @ApiProperty({ description: 'Conversation ID', example: 123 })
+  @IsNumber()
+  conversationId: number;
+
+  @ApiProperty({
+    description:
+      'Client-owned cursor. Returns messages with id greater than this value. ' +
+      'Bootstrap via chat-history first, then poll with the max message id.',
+    example: 456,
+  })
+  @IsNumber()
+  lastReadMessageId: number;
+}

--- a/src/conversations/messangers/envoye.spec.ts
+++ b/src/conversations/messangers/envoye.spec.ts
@@ -397,6 +397,117 @@ describe('EnvoyeMessenger', () => {
     });
   });
 
+  describe('loadMessagesSince', () => {
+    it('returns messages since lastReadMessageId without advancing the DB cursor', async () => {
+      const { workspace, chatHistory, sender, recipient } =
+        await mockWorkspaceWithConversationHistory();
+
+      const conversation = await singeParticipantMessageHistory(
+        workspace,
+        messenger,
+        [
+          ...chatHistory,
+          {
+            senderId: recipient.id,
+            messages: ['talk later'],
+            sentAt: addMinutes(chatHistory[4].sentAt, 5),
+          },
+        ],
+      );
+
+      const messages = await prismaService.message.findMany({
+        where: { conversationId: conversation.id },
+        orderBy: { sentAt: 'asc' },
+      });
+
+      const participantInfo =
+        await prismaService.conversationParticipant.findFirstOrThrow({
+          where: { teammateId: sender.id, conversationId: conversation.id },
+        });
+
+      expect(participantInfo.lastReadMessage).toBeNull();
+
+      const messagesSinceCursor = await messenger.loadMessagesSince(
+        conversation.id,
+        messages[3].id,
+      );
+
+      expect(messagesSinceCursor.map((msg) => msg.id)).toEqual([
+        messages[4].id,
+        messages[5].id,
+      ]);
+
+      const participantAfterFetch =
+        await prismaService.conversationParticipant.findFirstOrThrow({
+          where: { id: participantInfo.id },
+        });
+      expect(participantAfterFetch.lastReadMessage).toBeNull();
+    });
+
+    it('returns the same messages for repeated calls with the same cursor', async () => {
+      const { workspace, chatHistory, recipient } =
+        await mockWorkspaceWithConversationHistory();
+
+      const conversation = await singeParticipantMessageHistory(
+        workspace,
+        messenger,
+        [
+          ...chatHistory,
+          {
+            senderId: recipient.id,
+            messages: ['talk later'],
+            sentAt: addMinutes(chatHistory[4].sentAt, 5),
+          },
+        ],
+      );
+
+      const messages = await prismaService.message.findMany({
+        where: { conversationId: conversation.id },
+        orderBy: { sentAt: 'asc' },
+      });
+
+      const firstFetch = await messenger.loadMessagesSince(
+        conversation.id,
+        messages[3].id,
+      );
+      const secondFetch = await messenger.loadMessagesSince(
+        conversation.id,
+        messages[3].id,
+      );
+
+      expect(firstFetch.map((msg) => msg.id)).toEqual([
+        messages[4].id,
+        messages[5].id,
+      ]);
+      expect(secondFetch.map((msg) => msg.id)).toEqual(
+        firstFetch.map((msg) => msg.id),
+      );
+    });
+
+    it('returns an empty list when there are no messages after the cursor', async () => {
+      const { workspace, chatHistory } =
+        await mockWorkspaceWithConversationHistory();
+
+      const conversation = await singeParticipantMessageHistory(
+        workspace,
+        messenger,
+        chatHistory,
+      );
+
+      const messages = await prismaService.message.findMany({
+        where: { conversationId: conversation.id },
+        orderBy: { sentAt: 'asc' },
+      });
+
+      const messagesSinceCursor = await messenger.loadMessagesSince(
+        conversation.id,
+        messages[messages.length - 1].id,
+      );
+
+      expect(messagesSinceCursor).toEqual([]);
+    });
+  });
+
   describe('load conversations', () => {
     async function setupMixedConversationTypes() {
       const { workspace, teammates } =

--- a/src/conversations/messangers/envoye.ts
+++ b/src/conversations/messangers/envoye.ts
@@ -59,6 +59,27 @@ export default class EnvoyeMessenger implements Messenger {
     return messages.map((message) => toDomainMessage(message));
   }
 
+  async loadMessagesSince(
+    conversationId: number,
+    lastReadMessageId: number,
+    limit = 100,
+  ): Promise<DomainMessage[]> {
+    const messages = await this.prisma.message.findMany({
+      take: limit,
+      orderBy: {
+        sentAt: 'asc',
+      },
+      where: {
+        conversationId,
+        id: {
+          gt: lastReadMessageId,
+        },
+      },
+    });
+
+    return messages.map((message) => toDomainMessage(message));
+  }
+
   // TODO: add load previous messages.
   // TODO: add load most recent messages.
   // TODO: remove chat history.


### PR DESCRIPTION
## Summary

Towards https://github.com/exwestafrican/wagz/issues/263

The current unreadMessages endpoint in ConversationsController doesn't work well when a user has multiple clients connected.

For example, if messages m1–m4 arrive on the phone, the phone fetches m3 and m4 and marks them as read. On another client, those messages are now considered read in the database, so it only sees m1 and m2. When m5 arrives, the other client ends up with m1, m2, and m5, missing m3 and m4.

Instead, we should have the client send its lastReadMessageId and return all messages after that. This would allow each client to stay in sync independently. We could then deprecate the unreadMessages endpoint.